### PR TITLE
Add Slovenian translation to config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,8 @@ export const defaultConfiguration = {
     nb_NO: 'Norwegian, Norsk (bokmål)',
     vi_VN: 'Vietnamese, Vietnamese',
     fr_FR: 'French',
-    de_DE: 'German'
+    de_DE: 'German',
+    sl_SI: 'Slovenian, Slovenščina'
   },
 
   application: {


### PR DESCRIPTION
Add Slovenian translation to config. Real translation is already added in #18, but I forgot to add it to config.