### PR TITLE
Option to set window move shortcut

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -201,7 +201,8 @@ export const defaultConfiguration = {
   windows: {
     lofi: false,
     mobile: false, // Trigger for setting mobile UI
-    template: null // A string. See 'window.js' for example
+    template: null, // A string. See 'window.js' for example
+    moveKeybinding: 'ctrl'
   },
 
   vfs: {

--- a/src/utils/input.js
+++ b/src/utils/input.js
@@ -37,7 +37,7 @@ const modifierNames =  ['ctrl', 'shift', 'alt', 'meta'];
  * @return {boolean}
  */
 export const matchKeyCombo = (combo, ev) => {
-  const checkKeys = combo.toLowerCase().split('+');
+  const checkKeys = String(combo).toLowerCase().split('+');
   const keyName = String(ev.key).toLowerCase();
   const validKeypress = checkKeys.every(k => modifierNames.indexOf(k) !== -1
     ? ev[k + 'Key']

--- a/src/window-behavior.js
+++ b/src/window-behavior.js
@@ -29,7 +29,7 @@
  */
 
 import {supportsPassive} from './utils/dom';
-import {getEvent} from './utils/input';
+import {getEvent, matchKeyCombo} from './utils/input';
 import {resizer, mover, getMediaQueryName, getCascadePosition} from './utils/windows';
 
 const isPassive = supportsPassive();
@@ -186,10 +186,10 @@ export default class WindowBehavior {
     let attributeSet = false;
 
     const {moveable, resizable} = win.attributes;
-    const {lofi} = this.core.config('windows');
+    const {lofi, moveKeybinding} = this.core.config('windows');
     const {clientX, clientY, touch, target} = getEvent(ev);
 
-    const checkMove = ev.ctrlKey
+    const checkMove = matchKeyCombo(moveKeybinding, ev)
       ? win.$element.contains(target)
       : target.classList.contains('osjs-window-header');
 


### PR DESCRIPTION
> The configuration option 'windows.moveKeybinding' now allows for setting
which key(s) that handle the movement of window modifier. By default
this is set to 'ctrl', but can be any key combination that the input
handler supports (ex, 'ctrl+m'), or `false`/`null` to disable.