### PR TITLE
Added abitlity to make VFS group checking non-strict (#85)

### DIFF
--- a/__tests__/utils/vfs.js
+++ b/__tests__/utils/vfs.js
@@ -266,10 +266,15 @@ describe('utils.vfs#filterMountByGroups', () => {
     expect(vfs.filterMountByGroups([])(null)).toBe(true);
     expect(vfs.filterMountByGroups(['a'])(['a'])).toBe(true);
     expect(vfs.filterMountByGroups(['a', 'b'])(['a'])).toBe(true);
+
+    expect(vfs.filterMountByGroups(['a'])(['a'], false)).toBe(true);
+    expect(vfs.filterMountByGroups(['a', 'b'])(['a'], false)).toBe(true);
+    expect(vfs.filterMountByGroups(['a'])(['a', 'b'], false)).toBe(true);
   });
 
   test('Should be false', () => {
     expect(vfs.filterMountByGroups([])(['a'])).toBe(false);
     expect(vfs.filterMountByGroups(['a'])(['a', 'b'])).toBe(false);
+    expect(vfs.filterMountByGroups(['b'])(['a'], false)).toBe(false);
   });
 });

--- a/src/filesystem.js
+++ b/src/filesystem.js
@@ -317,7 +317,11 @@ export default class Filesystem extends EventEmitter {
     return this.mounts
       .filter(m => all || m.mounted)
       .filter(m => m.enabled !== false)
-      .filter(m => filterMountByGroups(user.groups)(m.attributes ? m.attributes.groups : []))
+      .filter(m => {
+        const mg = m.attributes ? m.attributes.groups : [];
+        const ms = m.attributes ? m.attributes.strictGroups !== false : true;
+        return filterMountByGroups(user.groups)(mg, ms);
+      })
       .map(m => ({
         attributes: Object.assign({}, m.attributes),
         icon: icon(m.icon),

--- a/src/utils/vfs.js
+++ b/src/utils/vfs.js
@@ -333,7 +333,8 @@ export const parseMontpointPrefix = str => {
  * Filters a mountpoint by user groups
  * @return {boolean}
  */
-export const filterMountByGroups = userGroups => mountGroups => mountGroups instanceof Array
-  ? mountGroups.every(g => userGroups.indexOf(g) !== -1)
-  : true;
+export const filterMountByGroups = userGroups => (mountGroups, strict = true) =>
+  mountGroups instanceof Array
+    ? mountGroups[strict ? 'every' : 'some'](g => userGroups.indexOf(g) !== -1)
+    : true;
 


### PR DESCRIPTION
The `strictGroups: false` mountpoint attribute can now make it so group
matching is less strict. I.e. user can belong to *some* of the groups,
not *all* of them.