### PR TITLE
Fixed some behavior relating to translation fallbacks

### DIFF
--- a/__tests__/utils/locale.js
+++ b/__tests__/utils/locale.js
@@ -2,6 +2,7 @@ import {createInstance} from 'osjs';
 import {
   clientLocale,
   format,
+  translate,
   translatable,
   translatableFlat,
   getLocale
@@ -61,5 +62,31 @@ describe('Locale Utils', () => {
 
     expect(getLocale(core, 'format.shortDate'))
       .toEqual({defaultLocale: 'yyyy-mm-dd', userLocale: 'yyyy-mm-dd'});
+  });
+
+  test('translate', () => {
+    expect(translate(
+      {
+        en_EN: {
+          hello: 'Hello World'
+        }
+      },
+      'en_EN',
+      'en_EN',
+      'hello'
+    )).toBe('Hello World')
+
+    expect(translate(
+      {
+        en_EN: {
+          hello: 'Hello World'
+        },
+        foo_BAR: {
+        }
+      },
+      'foo_BAR',
+      'foo_BAR',
+      'hello'
+    )).toBe('Hello World')
   });
 });

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -73,8 +73,14 @@ export const getLocale = (core, key) => {
  * @return {string}           The raw string
  */
 const getFromList = (list, ul, dl, k) => {
-  const localizedList = list[ul] || list[dl] || list[FALLBACK_LOCALE] || {};
-  return localizedList[k] || k;
+  const fallbackList = list[FALLBACK_LOCALE] || {};
+  const localizedList = list[ul] || list[dl] || {};
+
+  if (typeof localizedList[k] === 'undefined') {
+    return fallbackList[k] || k;
+  }
+
+  return localizedList[k];
 };
 
 /**
@@ -91,7 +97,7 @@ const getFromList = (list, ul, dl, k) => {
  * @param {...*}    args      A list of arguments that are defined in the translation string
  * @return {string}           The translated string
  */
-const translate = (list, ul, dl, k, ...args) => {
+export const translate = (list, ul, dl, k, ...args) => {
   const fmt = getFromList(list, ul, dl, k);
   return fmt.replace(sprintfRegex, sprintfMatcher(args));
 };


### PR DESCRIPTION
Previously if the user locale and the default locale matched up it could
lead to getting undefined translations, leading to displaying the key
name instead.