### PR TITLE
Added posibility to override Splash screen (#110)

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,3 +47,4 @@ export {default as VFSServiceProvider} from './src/providers/vfs';
 export {default as AuthServiceProvider} from './src/providers/auth';
 export {default as SettingsServiceProvider} from './src/providers/settings';
 export {default as logger} from './src/logger';
+export {default as Splash} from './src/splash';

--- a/src/core.js
+++ b/src/core.js
@@ -51,6 +51,7 @@ export default class Core extends CoreBase {
    * @param {Element} [options.root] The root DOM element for elements
    * @param {Element} [options.resourceRoot] The root DOM element for resources
    * @param {String[]} [options.classNames] List of class names to apply to root dom element
+   * @param {Function} [options.splash] Custom callback function for creating splash screen
    */
   constructor(config = {}, options = {}) {
     options = {
@@ -64,7 +65,7 @@ export default class Core extends CoreBase {
     this.logger = logger;
     this.ws = null;
     this.ping = null;
-    this.splash = new Splash(this);
+    this.splash = options.splash ? options.splash(this) : new Splash(this);
     this.$root = options.root;
     this.$resourceRoot = options.resourceRoot || document.querySelector('head');
     this.requestOptions = {};
@@ -83,6 +84,8 @@ export default class Core extends CoreBase {
 
       this.configuration.ws.uri = protocol.replace(/^http/, 'ws') + '//' + host + uri.replace(/^\/+/, '/');
     }
+
+    this.splash.init();
   }
 
   /**

--- a/src/splash.js
+++ b/src/splash.js
@@ -33,12 +33,15 @@ export default class Splash {
     this.core = core;
     this.$loading = document.createElement('div');
     this.$loading.className = 'osjs-boot-splash';
-    this.$loading.appendChild(document.createTextNode('Loading...'));
 
     core.on('osjs/core:boot', () => this.show());
     core.on('osjs/core:booted', () => this.destroy());
     core.on('osjs/core:logged-in', () => this.show());
     core.on('osjs/core:started', () => this.destroy());
+  }
+
+  init() {
+    this.$loading.appendChild(document.createTextNode('Loading...'));
   }
 
   show() {


### PR DESCRIPTION
This commit adds the following option and export to allow override of
the initial splash screen.

Example:

```javascript
import {Core, Splash} from '@osjs/client';

class CustomSplash extends Splash {
  init() {
    // This is the default, you can override this
    this.$loading
      .appendChild(document.createTextNode('Loading...'));
  }
}

// In your bootstrap add an option to a callback
// to point to the new splash instance.
new Core(config, {
  splash: core => new CustomSplash(core)
});
```