### PR TITLE
Add config option to override application window options (#115)

### DIFF
--- a/__tests__/utils/windows.js
+++ b/__tests__/utils/windows.js
@@ -215,3 +215,72 @@ describe('Window Resizer', () => {
   test('resize W', () => expect(resizer('w', -10, 10)).toEqual({top: 100, left: 90, width: 110, height: 100}));
   test('resize NW', () => expect(resizer('nw', -10, -10)).toEqual({top: 90, left: 90, width: 110, height: 110}));
 });
+
+describe('Load options from config', () => {
+  const config = [{
+    application: 'Application1',
+    options: {
+      attributes: {
+        foo: 'bar'
+      }
+    }
+  }, {
+    application: 'Application2',
+    window: 'Gaga',
+    options: {
+      attributes: {
+        bass: 'jazz'
+      }
+    }
+  }, {
+    window: /^RegExp_/,
+    options: {
+      attributes: {
+        test: 'jest'
+      }
+    }
+  }, {
+  }];
+
+  test('all application windows', () => {
+    const result = {attributes: {foo: 'bar'}};
+    expect(windows.loadOptionsFromConfig(config, 'Application1', 'Koko')).toEqual(result);
+    expect(windows.loadOptionsFromConfig(config, 'Application1', 'Kokoko')).toEqual(result);
+    expect(windows.loadOptionsFromConfig(config, 'Application1')).toEqual(result);
+    expect(windows.loadOptionsFromConfig(config, 'Application2', 'Koko')).toEqual({});
+  });
+
+  test('application spesific window', () => {
+    expect(windows.loadOptionsFromConfig(config, 'Application2', 'Gaga')).toEqual({
+      attributes: {
+        bass: 'jazz'
+      }
+    });
+
+    expect(windows.loadOptionsFromConfig(config, 'Application2', 'Gagaga')).toEqual({});
+  });
+
+  test('global window', () => {
+    expect(windows.loadOptionsFromConfig(config, 'undefined', 'RegExp_123')).toEqual({
+      attributes: {
+        test: 'jest'
+      }
+    });
+
+    expect(windows.loadOptionsFromConfig([
+      ...config,
+      {
+        window: /(.*)/,
+        options: {
+          attributes: {
+            all: 'thethings'
+          }
+        }
+      }
+    ], 'undefined')).toEqual({
+      attributes: {
+        all: 'thethings'
+      }
+    });
+  });
+});

--- a/src/application.js
+++ b/src/application.js
@@ -27,7 +27,9 @@
  * @author  Anders Evenrud <andersevenrud@gmail.com>
  * @licence Simplified BSD License
  */
+import merge from 'deepmerge';
 import {EventEmitter} from '@osjs/event-emitter';
+import {loadOptionsFromConfig} from './utils/windows';
 import Websocket from './websocket';
 import Window from './window';
 import logger from './logger';
@@ -308,7 +310,9 @@ export default class Application extends EventEmitter {
       throw new Error(msg);
     }
 
-    const instance = new Window(this.core, options);
+    const configWindows = this.core.config('application.windows', []);
+    const applyOptions = loadOptionsFromConfig(configWindows, this.metadata.name, options.id);
+    const instance = new Window(this.core, merge(options, applyOptions));
 
     if (this.options.restore) {
       const windows = this.options.restore.windows || [];

--- a/src/config.js
+++ b/src/config.js
@@ -119,7 +119,20 @@ export const defaultConfiguration = {
         label: 'LBL_APP_CAT_OTHER',
         icon: 'applications-other'
       }
-    }
+    },
+    windows: [
+      /*
+      {
+        application: string | RegExp | undefined,
+        window: string | RegExp | undefined,
+        options: {
+          dimension: object | undefined,
+          position: object | undefined,
+          attributes: object | undefined
+        }
+      }
+      */
+    ]
   },
 
   auth: {

--- a/src/utils/windows.js
+++ b/src/utils/windows.js
@@ -332,3 +332,32 @@ export const getMediaQueryName = (win) => Object.keys(win.attributes.mediaQuerie
     height: win.$element.offsetHeight || win.state.dimension.height
   }))
   .pop();
+
+/**
+ * Loads [certain] window options from configuration
+ */
+export const loadOptionsFromConfig = (config, appName, windowId) => {
+  const matchStringOrRegex = (str, matcher) => matcher instanceof RegExp
+    ? !!str.match(matcher)
+    : str === matcher;
+
+  const found = config.find(({application, window}) => {
+    if (!application && !window) {
+      return false;
+    } else if (application && !matchStringOrRegex(appName, application)) {
+      return false;
+    } else if (window && !matchStringOrRegex(windowId || '', window)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  const foundOptions = found && found.options ? found.options : {};
+  const allowedProperties = ['position', 'dimension', 'attributes'];
+
+  return allowedProperties.reduce((obj, key) => (foundOptions[key]
+    ? {...obj, [key]: foundOptions[key]}
+    : obj),
+  {});
+};


### PR DESCRIPTION
This PR adds the option to override any application default window spawn option via core configuration.

Schema is (in `src/client/config.js`):

```
{
  application: {
    windows: [
      {
        // Application metadata name
        application: string | RegExp | undefined,

        // Window ID      
        window: string | RegExp | undefined,

        // The following options are overridable
        options: {
          dimension: WindowDimension?,
          position: WindowPosition?,
          attributes: WindowAttributes?
        }
      }
    ]
  }
}
```

If no `application` is defined, the options will override any `window` match (with is the `id` option assigned to a window on construction. Note that a Window ID is unique per application, not globally.)