### PR TITLE
Fix overflow icon size

### DIFF
--- a/src/styles/_iconview.scss
+++ b/src/styles/_iconview.scss
@@ -75,6 +75,10 @@
         bottom: 0;
         right: 0;
       }
+
+      &__icon {
+        width: 100%;
+      }
     }
 
     &__label {


### PR DESCRIPTION
From this:
![image](https://user-images.githubusercontent.com/6000592/84604985-fb86e980-aec3-11ea-805a-62402e30d13a.png)
To this:
![image](https://user-images.githubusercontent.com/6000592/84604992-06417e80-aec4-11ea-840d-24af63f1dbf7.png)
