### PR TITLE
Added config option to hide packages via user groups (#140)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -78,7 +78,8 @@ export const defaultConfiguration = {
   packages: {
     manifest: '/metadata.json',
     metadata: [],
-    hidden: []
+    hidden: [],
+    permissions: {}
   },
 
   // FIXME: Move into packages above ?!

--- a/src/locale/en_EN.js
+++ b/src/locale/en_EN.js
@@ -37,6 +37,7 @@ export const en_EN = {
   ERR_VFS_MOUNT_NOT_MOUNTED: 'Filesystem \'{0}\' not mounted',
   ERR_VFS_MOUNT_ALREADY_MOUNTED: 'Filesystem \'{0}\' already mounted',
   ERR_VFS_PATH_FORMAT_INVALID: 'Given path \'{0}\' does not match \'name:/path\'',
+  ERR_PACKAGE_PERMISSION_DENIED: 'You are not permitted to run \'{0}\'',
   ERR_PACKAGE_NOT_FOUND: 'Package Metadata \'{0}\' not found',
   ERR_PACKAGE_LOAD: 'Package Loading \'{0}\' failed: {1}',
   ERR_PACKAGE_NO_RUNTIME: 'Package Runtime \'{0}\' not found',

--- a/src/packages.js
+++ b/src/packages.js
@@ -410,13 +410,24 @@ export default class Packages {
     const user = this.core.getUser();
     const metadata = this.metadata.map(m => ({...m}));
     const hidden = this.core.config('packages.hidden', []);
+    const permissions = this.core.config('packages.permissions', {});
 
-    const filterGroups = iter => {
+    const filterMetadataGroups = iter => {
       const m = iter.strictGroups === false ? 'some' : 'every';
 
       return iter.groups instanceof Array
         ? iter.groups[m](g => user.groups.indexOf(g) !== -1)
         : true;
+    };
+
+    const filterConfigGroups = iter => {
+      const perm = permissions[iter.name];
+      if (perm && perm.groups instanceof Array) {
+        const m = perm.strictGroups === false ? 'some' : 'every';
+        return perm.groups[m](g => user.groups.indexOf(g) !== -1);
+      }
+
+      return true;
     };
 
     const filterBlacklist = iter => user.blacklist instanceof Array
@@ -428,7 +439,8 @@ export default class Packages {
       : true;
 
     return metadata
-      .filter(filterGroups)
+      .filter(filterMetadataGroups)
+      .filter(filterConfigGroups)
       .filter(filterBlacklist)
       .filter(filterConfigHidden)
       .filter(filter);

--- a/src/utils/packages.js
+++ b/src/utils/packages.js
@@ -1,0 +1,64 @@
+/*
+ * OS.js - JavaScript Cloud/Web Desktop Platform
+ *
+ * Copyright (c) 2011-2020, Anders Evenrud <andersevenrud@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author  Anders Evenrud <andersevenrud@gmail.com>
+ * @license Simplified BSD License
+ */
+
+export const createPackageAvailabilityCheck = (core) => {
+  const user = core.getUser();
+  const permissions = core.config('packages.permissions', {});
+
+  const checkMetadataGroups = iter => {
+    const m = iter.strictGroups === false ? 'some' : 'every';
+
+    return iter.groups instanceof Array
+      ? iter.groups[m](g => user.groups.indexOf(g) !== -1)
+      : true;
+  };
+
+  const checkConfigGroups = iter => {
+    const perm = permissions[iter.name];
+    if (perm && perm.groups instanceof Array) {
+      const m = perm.strictGroups === false ? 'some' : 'every';
+      return perm.groups[m](g => user.groups.indexOf(g) !== -1);
+    }
+
+    return true;
+  };
+
+  const checkBlacklist = iter => user.blacklist instanceof Array
+    ? user.blacklist.indexOf(iter.name) === -1
+    : true;
+
+  const checks =  [
+    checkMetadataGroups,
+    checkConfigGroups,
+    checkBlacklist
+  ];
+
+  return metadata => checks.every(fn => fn(metadata));
+};


### PR DESCRIPTION
The following configuration entry is now available:

```
{
  packages: {
    permissions: {
      PackageName: {
        // Set to true to match *all* groups instead of *some*
        strictGroups: false,
        groups: ['a', 'b', 'c']
      }
    }
  }
}
```