### PR TITLE
Add middleware provider

### DIFF
--- a/__tests__/middleware.js
+++ b/__tests__/middleware.js
@@ -1,0 +1,69 @@
+import {createInstance} from 'osjs';
+import Middleware from '../src/middleware.js';
+
+describe('Middleware', () => {
+  let core;
+
+  beforeAll(() => {
+    return createInstance()
+      .then(c => (core = c));
+  });
+
+  afterAll(() => core.destroy());
+
+  test('#add', () => {
+    const middleware = new Middleware();
+    const callback = () => {};
+
+    middleware.add('group', callback);
+
+    expect(middleware.get('group')[0]).toEqual(callback);
+  });
+
+  test('#remove', () => {
+    const middleware = new Middleware();
+    const callback = () => {};
+
+    middleware.add('group', callback);
+    middleware.remove('group', callback);
+
+    expect(middleware.get('group').length).toEqual(0);
+  });
+
+  test('#clear', () => {
+    const middleware = new Middleware();
+    const callback = () => {};
+
+    middleware.add('group', callback);
+    middleware.clear();
+
+    expect(middleware.get('group').length).toEqual(0);
+  });
+
+  test('Should call all callbacks', () => {
+    const middleware = new Middleware();
+
+    const firstCallback = jest.fn(() => {});
+    const secondCallback = jest.fn(() => {});
+    const thirdCallback = jest.fn(() => {});
+
+    middleware.add('group', firstCallback);
+    middleware.add('group', secondCallback);
+    middleware.add('group', thirdCallback);
+
+    middleware.get('group').forEach(callback => callback());
+
+    expect(firstCallback).toBeCalled();
+    expect(secondCallback).toBeCalled();
+    expect(thirdCallback).toBeCalled();
+  });
+
+  test('#core middleware', () => {
+    const callback = () => {};
+    core.middleware('osjs/service', callback);
+
+    const middleware = core.make('osjs/middleware').get('osjs/service');
+
+    expect(middleware[0]).toEqual(callback);
+  });
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -960,6 +960,10 @@ declare class Core extends CoreBase {
 	 * Gets the current user
 	 */
 	getUser(): CoreUserData;
+	/**
+	 * Add middleware function to a group
+	 */
+	middleware(group: string, callback: Function): void;
 }
 export type SplashCallback = (core: Core) => Splash;
 /**
@@ -1805,6 +1809,37 @@ export type CliboardData = {
 	type?: string;
 	data: any;
 };
+declare class Middleware {
+	/**
+	 */
+	middleware: MiddlewareData;
+	/**
+	 * Destroy middleware
+	 */
+	destroy(): void;
+	/**
+	 * Clear middleware
+	 */
+	clear(): void;
+	/**
+	 * Add middleware function to a group
+	 */
+	add(group: string, callback: Function): void;
+	/**
+	 * Remove middleware function from a group
+	 */
+	remove(group: string, callback: Function): void;
+	/**
+	 * Gets middleware functions for a group
+	 */
+	get(group: string): Function[];
+}
+/**
+ * Middleware Data
+ */
+export type MiddlewareData = {
+	[group: string]: Function[]
+};
 declare class CoreServiceProvider extends ServiceProvider {
 	/**
 	 */
@@ -1821,6 +1856,9 @@ declare class CoreServiceProvider extends ServiceProvider {
 	/**
 	 */
 	readonly clipboard: Clipboard;
+	/**
+	 */
+	readonly middleware: Middleware;
 	/**
 	 * Registers contracts
 	 */
@@ -1880,6 +1918,10 @@ declare class CoreServiceProvider extends ServiceProvider {
 	 * Provides Clipboard contract
 	 */
 	createClipboardContract(): CoreProviderClipboardContract;
+	/**
+	 * Provides Middleware contract
+	 */
+	createMiddlewareContract(): CoreProviderMiddlewareContract;
 	/**
 	 * Provides Tray contract
 	 */
@@ -1951,13 +1993,20 @@ export type CoreProviderPackagesContract = {
 	running?: Function;
 };
 /**
- * Core Provider Tray Contract
+ * Core Provider Clipboard Contract
  */
 export type CoreProviderClipboardContract = {
 	clear?: Function;
 	set?: Function;
 	has?: Function;
 	get?: Function;
+};
+/**
+ * Core Provider Middleware Contract
+ */
+export type CoreProviderMiddlewareContract = {
+	add: Function;
+	get: Function;
 };
 /**
  * Core Provider Tray Contract
@@ -2471,6 +2520,7 @@ export {
 	Auth as Auth,
 	AuthServiceProvider as AuthServiceProvider,
 	Clipboard as Clipboard,
+	Middleware as Middleware,
 	Core as Core,
 	CoreServiceProvider as CoreServiceProvider,
 	Desktop as Desktop,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1777,7 +1777,7 @@ export type PackageLaunchOptions = {
 declare class Clipboard {
 	/**
 	 */
-	clipboard: CliboardData;
+	clipboard: ClipboardData;
 	/**
 	 * Destroy clipboard
 	 */
@@ -1802,7 +1802,7 @@ declare class Clipboard {
 /**
  * Clipboard Data
  */
-export type CliboardData = {
+export type ClipboardData = {
 	/**
 	 * Optional data type
 	 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1751,7 +1751,7 @@ export type PackageMetadata = {
 	/**
 	 * Files to preload
 	 */
-	files?: string[];
+	files?: Array<object | string>;
 	/**
 	 * A map of locales and titles
 	 */

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ export {default as Search} from './src/search';
 export {default as Packages} from './src/packages';
 export {default as Filesystem} from './src/filesystem';
 export {default as Clipboard} from './src/clipboard';
+export {default as Middleware} from './src/middleware';
 export {BasicApplication} from './src/basic-application';
 export {defaultConfiguration as configuration} from './src/config';
 export {default as icon} from './src/styles/logo-blue-32x32.png';

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -31,7 +31,7 @@
 /**
  * Clipboard Data
  *
- * @typedef {Object} CliboardData
+ * @typedef {Object} ClipboardData
  * @property {string} [type] Optional data type
  * @property {*} data
  */
@@ -46,7 +46,7 @@ export default class Clipboard {
    */
   constructor() {
     /**
-     * @type {CliboardData}
+     * @type {ClipboardData}
      */
     this.clipboard = undefined;
 

--- a/src/core.js
+++ b/src/core.js
@@ -658,4 +658,14 @@ export default class Core extends CoreBase {
     return {...this.user};
   }
 
+  /**
+   * Add middleware function to a group
+   *
+   * @param {string} group Middleware group
+   * @param {Function} callback Middleware function to add
+   */
+  middleware(group, callback) {
+    return this.make('osjs/middleware').add(group, callback);
+  }
+
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,100 @@
+/*
+ * OS.js - JavaScript Cloud/Web Desktop Platform
+ *
+ * Copyright (c) 2011-2020, Anders Evenrud <andersevenrud@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author  Anders Evenrud <andersevenrud@gmail.com>
+ * @license Simplified BSD License
+ */
+
+/**
+ * Middleware Data
+ *
+ * @typedef {Object} MiddlewareData
+ * @property {string} [group] Middleware group
+ */
+
+/**
+ * Middleware Manager
+ */
+export default class Middleware {
+
+  /**
+   * Create new middleware
+   */
+  constructor() {
+    /**
+     * @type {MiddlewareData}
+     */
+    this.middleware = {};
+  }
+
+  /**
+   * Destroy middleware
+   */
+  destroy() {
+    this.clear();
+  }
+
+  /**
+   * Clear middleware
+   */
+  clear() {
+    this.middleware = {};
+  }
+
+  /**
+   * Add middleware function to a group
+   * @param {string} group Middleware group
+   * @param {Function} callback Middleware function to add
+   */
+  add(group, callback) {
+    if (!this.middleware[group]) {
+      this.middleware[group] = [];
+    }
+
+    this.middleware[group].push(callback);
+  }
+
+  /**
+   * Remove middleware function from a group
+   * @param {string} group Middleware group
+   * @param {Function} callback Middleware function to remove
+   */
+  remove(group, callback) {
+    if (this.middleware[group]) {
+      this.middleware[group] =
+        this.middleware[group].filter(cb => cb !== callback);
+    }
+  }
+
+  /**
+   * Gets middleware functions for a group
+   * @param {string} group Middleware group
+   * @return {Function[]}
+   */
+  get(group) {
+    return this.middleware[group] || [];
+  }
+}

--- a/src/utils/packages.js
+++ b/src/utils/packages.js
@@ -62,3 +62,21 @@ export const createPackageAvailabilityCheck = (core) => {
 
   return metadata => checks.every(fn => fn(metadata));
 };
+
+export const createManifestFromArray = list => list
+  .map(iter => ({
+    type: 'application',
+    ...iter,
+    files: (iter.files || [])
+      .map(file =>
+        typeof file === 'string'
+          ? {filename: file, type: 'preload'}
+          : {type: 'preload', ...file}
+      )
+  }));
+
+export const filterMetadataFilesByType = (files, type) =>
+  (files || []).filter(file => file.type === type);
+
+export const metadataFilesToFilenames = files =>
+  (files || []).map(file => file.filename);


### PR DESCRIPTION
It adds `osjs/middleware` provider to the core. As an example, it can be used to dynamically add items to the context menu in the file manager application.

Closes https://github.com/os-js/OS.js/issues/752.