### PR TITLE
Add prefix to localStorage settings adapter (#159)

### DIFF
--- a/__tests__/adapters/settings/localstorage.js
+++ b/__tests__/adapters/settings/localstorage.js
@@ -3,14 +3,14 @@ import adapter from '../../../src/adapters/settings/localstorage.js';
 let core;
 
 describe('LocalStorage Settings Adapter', () => {
-  beforeAll(() => {
-    localStorage.setItem('failure', '{failure}');
+  beforeAll(async () => {
+    localStorage.setItem('osjs__failure', '{failure}');
 
-    createInstance().then(c => (core = c));
+    core = await createInstance();
   });
 
   afterAll(() => {
-    localStorage.removeItem('failure');
+    localStorage.removeItem('osjs__failure');
     core.destroy();
   });
 

--- a/src/config.js
+++ b/src/config.js
@@ -171,6 +171,7 @@ export const defaultConfiguration = {
 
   settings: {
     lock: [],
+    prefix: 'osjs__', // localStorage settings adapter key prefix
 
     defaults: {
       'osjs/default-application': {},


### PR DESCRIPTION
Avoid parsing of localStorage entries that does not contains a
configured prefix because it could contain data that has been set in
other applications under the same host.