### PR TITLE
Added support for labels and translated application titles on shortcuts.

### DIFF
--- a/src/adapters/ui/iconview.js
+++ b/src/adapters/ui/iconview.js
@@ -48,8 +48,8 @@ const createLabelComputer = (core) => {
   const packages = f => core.make('osjs/packages').getPackages(f)[0];
   const translate = n => core.make('osjs/locale').translatableFlat(n);
 
-  return ({filename, label}) => {
-    const metadata = packages(pkg => (pkg.name === filename));
+  return ({filename, mime, label}) => {
+    const metadata = (mime === 'osjs/application' ? packages(pkg => (pkg.name === filename)) : null);
     return label || (metadata ? translate(metadata.title) : filename);
   };
 };


### PR DESCRIPTION
- Formerly used 'label' property in shortcuts.json is utilized to override shortcut display name. Failback to filename as before.
- On shortcuts with the 'osjs/application' mime type and no label, the translated application title is used. 