### PR TITLE
VFS documentation typo

### DIFF
--- a/src/vfs.js
+++ b/src/vfs.js
@@ -135,7 +135,7 @@ export const rename = (adapter, mount) => (from, to, options = {}) =>
   adapter.rename(pathToObject(from), pathToObject(to), options, mount);
 
 /**
- * Alias of 'readme'
+ * Alias of 'rename'
  * @param {string|VFSFile} from The source (from)
  * @param {string|VFSFile} to The destination (to)
  * @param {VFSMethodOptions} [options] Options


### PR DESCRIPTION
Corrected `readme` to `rename` in the `move` function documentation.