### PR TITLE
Add VFS context aware sorting

### DIFF
--- a/__tests__/utils/vfs.js
+++ b/__tests__/utils/vfs.js
@@ -67,8 +67,8 @@ describe('utils.vfs#transformReaddir', () => {
     size: 666
   }];
 
-  const check = (options = {}) => vfs.transformReaddir({path: root}, input, options);
-  const checkMap = (options = {}, key = 'filename') => check(options).map(iter => iter[key]);
+  const check = (options = {}, capability = {}) => vfs.transformReaddir({path: root}, input, capability, options);
+  const checkMap = (options = {}, key = 'filename', capability = {}) => check(options, capability).map(iter => iter[key]);
 
   test('Should add parent directory', () => {
     expect(check({

--- a/__tests__/utils/vfs.js
+++ b/__tests__/utils/vfs.js
@@ -88,7 +88,7 @@ describe('utils.vfs#transformReaddir', () => {
   test('Should remove dotfiles', () => {
     expect(checkMap({
       showHiddenFiles: false
-    })).toEqual(['..', 'directory', 'xdirectory', 'file', 'xfile']);
+    })).toEqual(['..', 'directory', 'file', 'xdirectory', 'xfile']);
   });
 
   test('Should sort by descending order', () => {
@@ -98,7 +98,7 @@ describe('utils.vfs#transformReaddir', () => {
     });
 
     return expect(result)
-      .toEqual(['..', 'xdirectory', 'directory', 'xfile', 'file']);
+      .toEqual(['..', 'xfile', 'xdirectory', 'file', 'directory']);
   });
 
   test('Should sort by ascending order', () => {
@@ -108,7 +108,7 @@ describe('utils.vfs#transformReaddir', () => {
     });
 
     return expect(result)
-      .toEqual(['..', 'directory', 'xdirectory', 'file', 'xfile']);
+      .toEqual(['..', 'directory', 'file', 'xdirectory', 'xfile']);
   });
 
   test('Should sort by specified column', () => {

--- a/src/utils/vfs.js
+++ b/src/utils/vfs.js
@@ -79,6 +79,13 @@ const sortDefault = (k, d) => (a, b) =>
       : (d === 'asc' ? 0 : 1));
 
 /*
+ * Sort by ascii codes
+ */
+const sortAscii = (k, d) => (a, b) => d === 'asc'
+  ? (a[k] < b[k]) ? -1 : 1
+  : (a[k] < b[k]) ? 1 : -1;
+
+/*
  * Sorts an array of files
  */
 const sortFn = t => {
@@ -86,6 +93,8 @@ const sortFn = t => {
     return sortString;
   } else if (t === 'date') {
     return sortDate;
+  } else if (t === 'ascii') {
+    return sortAscii;
   }
 
   return sortDefault;
@@ -184,10 +193,7 @@ export const humanFileSize = (bytes, si = false) => {
  */
 export const transformReaddir = ({path}, files, capabilityCache, options = {}) => {
   const mountPoint = path => path.split(':/')[0];
-  let mountPointSort = false;
-  if(capabilityCache[mountPoint(path)] !== undefined) {
-    mountPointSort = capabilityCache[mountPoint(path)].sort;
-  }
+  const mountPointSort = capabilityCache[mountPoint(path)] ? capabilityCache[mountPoint(path)].sort : false;
 
   options = {
     showHiddenFiles: false,

--- a/src/vfs.js
+++ b/src/vfs.js
@@ -72,7 +72,7 @@ const pathToObject = path => ({
 // Handles directory listing result(s)
 const handleDirectoryList = (path, options) => result =>
   Promise.resolve(result.map(stat => createFileIter(stat)))
-    .then(result => transformReaddir(pathToObject(path), result, {
+    .then(result => transformReaddir(pathToObject(path), result, capabilityCache, {
       showHiddenFiles: options.showHiddenFiles !== false,
       filter: options.filter
     }));


### PR DESCRIPTION
Due to [this point](https://github.com/os-js/osjs-client/pull/164#issuecomment-913868931), we'd better to improve client-side sorting. 

In new code, client will sort only if **VFS server adapter** does not sort before.