### PR TITLE
SVG icon support

### DIFF
--- a/__tests__/utils/desktop.js
+++ b/__tests__/utils/desktop.js
@@ -2,19 +2,43 @@ import {createInstance} from 'osjs';
 import {resourceResolver} from '../../src/utils/desktop';
 
 describe('#resourceResolver icon themes', () => {
-  let core;
+  let resolver;
 
-  beforeAll(() => createInstance().then((c) => (core = c)));
+  beforeAll(() => createInstance().then(
+    (core) => (resolver = resourceResolver(core))
+  ));
   afterAll(() => core.destroy());
 
   test('Should work with image extensions in the icon name', () => {
-    const resolver = resourceResolver(core);
-
     expect(resolver.icon('test.png')).toBe(
       '/icons/GnomeIcons/icons/test.png'
     );
     expect(resolver.icon('test.svg')).toBe(
       '/icons/GnomeIcons/icons/test.png'
+    );
+  });
+
+  test('Should work without image extensions in the icon name', () => {
+    expect(resolver.icon('test')).toBe(
+      '/icons/GnomeIcons/icons/test.png'
+    );
+  });
+
+  test('Should work with multiple image extensions in the name', () => {
+    expect(resolver.icon('test.png.svg.gif')).toBe(
+      '/icons/GnomeIcons/icons/test.png.svg.png'
+    );
+  });
+
+  test('Should work on filenames with dots in them', () => {
+    expect(resolver.icon('test.icon.gif')).toBe(
+      '/icons/GnomeIcons/icons/test.icon.png'
+    );
+    expect(resolver.icon('test.icon')).toBe(
+      '/icons/GnomeIcons/icons/test.icon.png'
+    );
+    expect(resolver.icon('lots.of.dots.here')).toBe(
+      '/icons/GnomeIcons/icons/lots.of.dots.here.png'
     );
   });
 });

--- a/__tests__/utils/desktop.js
+++ b/__tests__/utils/desktop.js
@@ -1,0 +1,20 @@
+import {createInstance} from 'osjs';
+import {resourceResolver} from '../../src/utils/desktop';
+
+describe('#resourceResolver icon themes', () => {
+  let core;
+
+  beforeAll(() => createInstance().then((c) => (core = c)));
+  afterAll(() => core.destroy());
+
+  test('Should work with image extensions in the icon name', () => {
+    const resolver = resourceResolver(core);
+
+    expect(resolver.icon('test.png')).toBe(
+      '/icons/GnomeIcons/icons/test.png'
+    );
+    expect(resolver.icon('test.svg')).toBe(
+      '/icons/GnomeIcons/icons/test.png'
+    );
+  });
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -1552,7 +1552,7 @@ declare class Tray {
 
 	/**
 	 */
-  has(key): boolean;
+	has(key): boolean;
 }
 /**
  * Tray Icon Data
@@ -1991,6 +1991,7 @@ export type CoreProviderPackagesContract = {
 	getPackages?: Function;
 	getCompatiblePackages?: Function;
 	running?: Function;
+	getMetadataFromName?: Function;
 };
 /**
  * Core Provider Clipboard Contract
@@ -2013,9 +2014,9 @@ export type CoreProviderMiddlewareContract = {
  */
 export type CoreProviderTrayContract = {
 	create?: Function;
-  remove?: Function;
-  list?: TrayEntry[],
-  has?: boolean;
+	remove?: Function;
+	list?: TrayEntry[],
+	has?: boolean;
 
 };
 /**
@@ -2141,7 +2142,7 @@ declare class Filesystem extends EventEmitter {
 	/**
 	 * Gets configured mountpoints
 	 */
-  private _getConfiguredMountpoints;
+	private _getConfiguredMountpoints;
 }
 /**
  * VFS Mountpoint attributes

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,1186 +33,1186 @@ export as namespace osjs__client;
 import { EventEmitter } from '@osjs/event-emitter';
 
 declare class ServiceProvider {
-	/**
-	 * Core instance reference
-	 */
-	readonly core: CoreBase;
-	/**
-	 * Provider options
-	 */
-	readonly options: any;
-	/**
-	 * Constructor
-	 */
-	constructor(core: CoreBase, options: any);
-	/**
-	 * List of provided services
-	 */
-	provides(): string[];
-	/**
-	 * Initializes Provider
-	 */
-	init(): Promise<any>;
-	/**
-	 * Starts Provider
-	 */
-	start(): Promise<any>;
-	/**
-	 * Destroys Provider
-	 */
-	destroy(): void;
+  /**
+   * Core instance reference
+   */
+  readonly core: CoreBase;
+  /**
+   * Provider options
+   */
+  readonly options: any;
+  /**
+   * Constructor
+   */
+  constructor(core: CoreBase, options: any);
+  /**
+   * List of provided services
+   */
+  provides(): string[];
+  /**
+   * Initializes Provider
+   */
+  init(): Promise<any>;
+  /**
+   * Starts Provider
+   */
+  start(): Promise<any>;
+  /**
+   * Destroys Provider
+   */
+  destroy(): void;
 }
 declare class CoreBase extends EventEmitter {
-	/**
-	 * Logger module
-	 */
-	readonly logger: any;
-	/**
-	 * Configuration Tree
-	 */
-	readonly configuration: any;
-	/**
-	 * Options
-	 */
-	readonly options: any;
-	/**
-	 * Boot has been initiated
-	 */
-	booted: boolean;
-	/**
-	 * Fully started
-	 */
-	started: boolean;
-	/**
-	 * Fully destroyped
-	 */
-	destroyd: boolean;
-	/**
-	 * Service Provider Handler
-	 */
-	providers: any;
-	/**
-	 * Constructor
-	 */
-	constructor(name?: string);
-	/**
-	 * Destroy core instance
-	 */
-	destroy(): void;
-	/**
-	 * Boots up OS.js
-	 */
-	boot(): Promise<boolean>;
-	/**
-	 * Starts all core services
-	 */
-	start(): Promise<boolean>;
-	/**
-	 * Gets a configuration entry by key
-	 */
-	config(key: string, defaultValue: any): any;
-	/**
-	 * Register a service provider
-	 */
-	register(ref: typeof ServiceProvider, options: any): void;
-	/**
-	 * Register a instanciator provider
-	 */
-	instance(name: string, callback: Function): void;
-	/**
-	 * Register a singleton provider
-	 */
-	singleton(name: string, callback: Function): void;
-	/**
-	 * Create an instance of a provided service
-	 */
-	make<T>(name: string, ...args: any[]): T;
-	/**
-	 * Check if a service exists
-	 */
-	has(name: string): boolean;
+  /**
+   * Logger module
+   */
+  readonly logger: any;
+  /**
+   * Configuration Tree
+   */
+  readonly configuration: any;
+  /**
+   * Options
+   */
+  readonly options: any;
+  /**
+   * Boot has been initiated
+   */
+  booted: boolean;
+  /**
+   * Fully started
+   */
+  started: boolean;
+  /**
+   * Fully destroyped
+   */
+  destroyd: boolean;
+  /**
+   * Service Provider Handler
+   */
+  providers: any;
+  /**
+   * Constructor
+   */
+  constructor(name?: string);
+  /**
+   * Destroy core instance
+   */
+  destroy(): void;
+  /**
+   * Boots up OS.js
+   */
+  boot(): Promise<boolean>;
+  /**
+   * Starts all core services
+   */
+  start(): Promise<boolean>;
+  /**
+   * Gets a configuration entry by key
+   */
+  config(key: string, defaultValue: any): any;
+  /**
+   * Register a service provider
+   */
+  register(ref: typeof ServiceProvider, options: any): void;
+  /**
+   * Register a instanciator provider
+   */
+  instance(name: string, callback: Function): void;
+  /**
+   * Register a singleton provider
+   */
+  singleton(name: string, callback: Function): void;
+  /**
+   * Create an instance of a provided service
+   */
+  make<T>(name: string, ...args: any[]): T;
+  /**
+   * Check if a service exists
+   */
+  has(name: string): boolean;
 }
 declare class Websocket extends EventEmitter {
-	/**
-	 * Create a new Websocket
-	 */
-	constructor(name: string, uri: string, options?: WebsocketOptions);
-	/**
-	 * Socket URI
-	 */
-	readonly uri: string;
-	/**
-	 * If socket is closed
-	 */
-	closed: boolean;
-	/**
-	 * If socket is connected
-	 */
-	connected: boolean;
-	/**
-	 * If socket is connecting
-	 */
-	connecting: boolean;
-	/**
-	 * If socket is reconnecting
-	 */
-	reconnecting: boolean;
-	/**
-	 * If socket failed to connect
-	 */
-	connectfailed: boolean;
-	/**
-	 * Options
-	 */
-	readonly options: WebsocketOptions;
-	/**
-	 * The Websocket
-	 */
-	connection: WebSocket;
-	/**
-	 * Destroys the current connection
-	 */
-	private _destroyConnection;
-	/**
-	 * Attaches internal events
-	 */
-	private _attachEvents;
-	/**
-	 * Opens the connection
-	 */
-	open(reconnect?: boolean): void;
-	/**
-	 * Wrapper for sending data
-	 */
-	send(...args: any[]): void;
-	/**
-	 * Wrapper for closing
-	 */
-	close(...args: any[]): void;
+  /**
+   * Create a new Websocket
+   */
+  constructor(name: string, uri: string, options?: WebsocketOptions);
+  /**
+   * Socket URI
+   */
+  readonly uri: string;
+  /**
+   * If socket is closed
+   */
+  closed: boolean;
+  /**
+   * If socket is connected
+   */
+  connected: boolean;
+  /**
+   * If socket is connecting
+   */
+  connecting: boolean;
+  /**
+   * If socket is reconnecting
+   */
+  reconnecting: boolean;
+  /**
+   * If socket failed to connect
+   */
+  connectfailed: boolean;
+  /**
+   * Options
+   */
+  readonly options: WebsocketOptions;
+  /**
+   * The Websocket
+   */
+  connection: WebSocket;
+  /**
+   * Destroys the current connection
+   */
+  private _destroyConnection;
+  /**
+   * Attaches internal events
+   */
+  private _attachEvents;
+  /**
+   * Opens the connection
+   */
+  open(reconnect?: boolean): void;
+  /**
+   * Wrapper for sending data
+   */
+  send(...args: any[]): void;
+  /**
+   * Wrapper for closing
+   */
+  close(...args: any[]): void;
 }
 /**
  * Websocket options
  */
 export type WebsocketOptions = {
-	/**
-	 * Enable reconnection
-	 */
-	reconnect?: boolean;
-	/**
-	 * Reconnect interval
-	 */
-	interval?: number;
-	/**
-	 * Immediately open socket after creation
-	 */
-	open?: boolean;
+  /**
+   * Enable reconnection
+   */
+  reconnect?: boolean;
+  /**
+   * Reconnect interval
+   */
+  interval?: number;
+  /**
+   * Immediately open socket after creation
+   */
+  open?: boolean;
 };
 declare class Splash {
-	/**
-	 * Create Splash
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Splash root element
-	 */
-	readonly $loading: Element;
-	/**
-	 * Initializes splash
-	 */
-	init(): void;
-	/**
-	 * Shows splash
-	 */
-	show(): void;
-	/**
-	 * Destroys splash
-	 */
-	destroy(): void;
+  /**
+   * Create Splash
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Splash root element
+   */
+  readonly $loading: Element;
+  /**
+   * Initializes splash
+   */
+  init(): void;
+  /**
+   * Shows splash
+   */
+  show(): void;
+  /**
+   * Destroys splash
+   */
+  destroy(): void;
 }
 declare class Window extends EventEmitter {
-	/**
-	 * Get a list of all windows
-	 */
-	static getWindows(): Window[];
-	/**
-	 * Gets the lastly focused Window
-	 */
-	static lastWindow(): Window;
-	/**
-	 * Create window
-	 */
-	constructor(core: Core, options?: WindowOptions);
-	/**
-	 * The Window ID
-	 */
-	readonly id: string;
-	/**
-	 * The Window ID
-	 */
-	readonly wid: number;
-	/**
-	 * Parent Window reference
-	 */
-	readonly parent: Window;
-	/**
-	 * Child windows (via 'parent')
-	 */
-	children: Window[];
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * The window destruction state
-	 */
-	destroyed: boolean;
-	/**
-	 * The window rendered state
-	 */
-	rendered: boolean;
-	/**
-	 * The window was inited
-	 */
-	inited: boolean;
-	/**
-	 * The window attributes
-	 */
-	attributes: WindowAttributes;
-	/**
-	 * The window state
-	 */
-	state: WindowState;
-	/**
-	 * The window container
-	 */
-	readonly $element: Element;
-	/**
-	 * The content container
-	 */
-	$content: Element;
-	/**
-	 * The header container
-	 */
-	$header: Element;
-	/**
-	 * The icon container
-	 */
-	$icon: Element;
-	/**
-	 * The title container
-	 */
-	$title: Element;
-	/**
-	 * Internal variable to signal not to use default position
-	 * given by user (used for restore)
-	 */
-	private _preventDefaultPosition;
-	/**
-	 * Internal timeout reference used for triggering the loading
-	 * overlay.
-	 */
-	private _loadingDebounce;
-	/**
-	 * The window template
-	 */
-	private _template;
-	/**
-	 * Custom destructor callback
-	 */
-	private readonly _ondestroy;
-	/**
-	 * Last DOM update CSS text
-	 */
-	private _lastCssText;
-	/**
-	 * Last DOM update data attributes
-	 */
-	private _lastAttributes;
-	/**
-	 * Destroy window
-	 */
-	destroy(): void;
-	/**
-	 * Initialize window
-	 */
-	init(): Window;
-	/**
-	 * Initializes window template
-	 */
-	private _initTemplate;
-	/**
-	 * Initializes window behavior
-	 */
-	private _initBehavior;
-	/**
-	 * Checks the modal state of the window upon render
-	 */
-	private _checkModal;
-	/**
-	 * Sets the initial class names
-	 */
-	private _setClassNames;
-	/**
-	 * Render window
-	 */
-	render(callback?: Function): Window;
-	/**
-	 * Close the window
-	 */
-	close(): boolean;
-	/**
-	 * Focus the window
-	 */
-	focus(): boolean;
-	/**
-	 * Internal for focus
-	 */
-	private _focus;
-	/**
-	 * Blur (un-focus) the window
-	 */
-	blur(): boolean;
-	/**
-	 * Minimize (hide) the window
-	 */
-	minimize(): boolean;
-	/**
-	 * Raise (un-minimize) the window
-	 */
-	raise(): boolean;
-	/**
-	 * Maximize the window
-	 */
-	maximize(): boolean;
-	/**
-	 * Restore (un-maximize) the window
-	 */
-	restore(): boolean;
-	/**
-	 * Internal for Maximize or restore
-	 */
-	private _maximize;
-	/**
-	 * Resize to fit to current container
-	 */
-	resizeFit(container?: Element): void;
-	/**
-	 * Clamps the position to viewport
-	 */
-	clampToViewport(update?: boolean): void;
-	/**
-	 * Set the Window icon
-	 */
-	setIcon(uri: string): void;
-	/**
-	 * Set the Window title
-	 */
-	setTitle(title: string): void;
-	/**
-	 * Set the Window dimension
-	 */
-	setDimension(dimension: WindowDimension): void;
-	/**
-	 * Set the Window position
-	 */
-	setPosition(position: WindowPosition, preventDefault?: boolean): void;
-	/**
-	 * Set the Window z index
-	 */
-	setZindex(zIndex: number): void;
-	/**
-	 * Sets the Window to next z index
-	 */
-	setNextZindex(force?: boolean): void;
-	/**
-	 * Set a state by value
-	 */
-	setState(name: string, value: any, update?: boolean): void;
-	/**
-	 * Gravitates window towards a certain area
-	 */
-	gravitate(gravity: string): void;
-	/**
-	 * Gets a astate
-	 */
-	getState(n: any): any;
-	/**
-	 * Get a snapshot of the Window session
-	 */
-	getSession(): WindowSession;
-	/**
-	 * Internal method for setting state
-	 */
-	private _setState;
-	/**
-	 * Internal method for toggling state
-	 */
-	private _toggleState;
-	/**
-	 * Check if we have to set next zindex
-	 */
-	private _checkNextZindex;
-	_updateDOM(): void;
-	/**
-	 * Updates the window buttons in DOM
-	 */
-	private _updateButtons;
-	/**
-	 * Updates window title in DOM
-	 */
-	private _updateTitle;
-	/**
-	 * Updates window icon decoration in DOM
-	 */
-	private _updateIconStyles;
-	/**
-	 * Updates window header decoration in DOM
-	 */
-	private _updateHeaderStyles;
-	/**
-	 * Updates window data in DOM
-	 */
-	private _updateAttributes;
-	/**
-	 * Updates window style in DOM
-	 */
-	private _updateStyles;
+  /**
+   * Get a list of all windows
+   */
+  static getWindows(): Window[];
+  /**
+   * Gets the lastly focused Window
+   */
+  static lastWindow(): Window;
+  /**
+   * Create window
+   */
+  constructor(core: Core, options?: WindowOptions);
+  /**
+   * The Window ID
+   */
+  readonly id: string;
+  /**
+   * The Window ID
+   */
+  readonly wid: number;
+  /**
+   * Parent Window reference
+   */
+  readonly parent: Window;
+  /**
+   * Child windows (via 'parent')
+   */
+  children: Window[];
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * The window destruction state
+   */
+  destroyed: boolean;
+  /**
+   * The window rendered state
+   */
+  rendered: boolean;
+  /**
+   * The window was inited
+   */
+  inited: boolean;
+  /**
+   * The window attributes
+   */
+  attributes: WindowAttributes;
+  /**
+   * The window state
+   */
+  state: WindowState;
+  /**
+   * The window container
+   */
+  readonly $element: Element;
+  /**
+   * The content container
+   */
+  $content: Element;
+  /**
+   * The header container
+   */
+  $header: Element;
+  /**
+   * The icon container
+   */
+  $icon: Element;
+  /**
+   * The title container
+   */
+  $title: Element;
+  /**
+   * Internal variable to signal not to use default position
+   * given by user (used for restore)
+   */
+  private _preventDefaultPosition;
+  /**
+   * Internal timeout reference used for triggering the loading
+   * overlay.
+   */
+  private _loadingDebounce;
+  /**
+   * The window template
+   */
+  private _template;
+  /**
+   * Custom destructor callback
+   */
+  private readonly _ondestroy;
+  /**
+   * Last DOM update CSS text
+   */
+  private _lastCssText;
+  /**
+   * Last DOM update data attributes
+   */
+  private _lastAttributes;
+  /**
+   * Destroy window
+   */
+  destroy(): void;
+  /**
+   * Initialize window
+   */
+  init(): Window;
+  /**
+   * Initializes window template
+   */
+  private _initTemplate;
+  /**
+   * Initializes window behavior
+   */
+  private _initBehavior;
+  /**
+   * Checks the modal state of the window upon render
+   */
+  private _checkModal;
+  /**
+   * Sets the initial class names
+   */
+  private _setClassNames;
+  /**
+   * Render window
+   */
+  render(callback?: Function): Window;
+  /**
+   * Close the window
+   */
+  close(): boolean;
+  /**
+   * Focus the window
+   */
+  focus(): boolean;
+  /**
+   * Internal for focus
+   */
+  private _focus;
+  /**
+   * Blur (un-focus) the window
+   */
+  blur(): boolean;
+  /**
+   * Minimize (hide) the window
+   */
+  minimize(): boolean;
+  /**
+   * Raise (un-minimize) the window
+   */
+  raise(): boolean;
+  /**
+   * Maximize the window
+   */
+  maximize(): boolean;
+  /**
+   * Restore (un-maximize) the window
+   */
+  restore(): boolean;
+  /**
+   * Internal for Maximize or restore
+   */
+  private _maximize;
+  /**
+   * Resize to fit to current container
+   */
+  resizeFit(container?: Element): void;
+  /**
+   * Clamps the position to viewport
+   */
+  clampToViewport(update?: boolean): void;
+  /**
+   * Set the Window icon
+   */
+  setIcon(uri: string): void;
+  /**
+   * Set the Window title
+   */
+  setTitle(title: string): void;
+  /**
+   * Set the Window dimension
+   */
+  setDimension(dimension: WindowDimension): void;
+  /**
+   * Set the Window position
+   */
+  setPosition(position: WindowPosition, preventDefault?: boolean): void;
+  /**
+   * Set the Window z index
+   */
+  setZindex(zIndex: number): void;
+  /**
+   * Sets the Window to next z index
+   */
+  setNextZindex(force?: boolean): void;
+  /**
+   * Set a state by value
+   */
+  setState(name: string, value: any, update?: boolean): void;
+  /**
+   * Gravitates window towards a certain area
+   */
+  gravitate(gravity: string): void;
+  /**
+   * Gets a astate
+   */
+  getState(n: any): any;
+  /**
+   * Get a snapshot of the Window session
+   */
+  getSession(): WindowSession;
+  /**
+   * Internal method for setting state
+   */
+  private _setState;
+  /**
+   * Internal method for toggling state
+   */
+  private _toggleState;
+  /**
+   * Check if we have to set next zindex
+   */
+  private _checkNextZindex;
+  _updateDOM(): void;
+  /**
+   * Updates the window buttons in DOM
+   */
+  private _updateButtons;
+  /**
+   * Updates window title in DOM
+   */
+  private _updateTitle;
+  /**
+   * Updates window icon decoration in DOM
+   */
+  private _updateIconStyles;
+  /**
+   * Updates window header decoration in DOM
+   */
+  private _updateHeaderStyles;
+  /**
+   * Updates window data in DOM
+   */
+  private _updateAttributes;
+  /**
+   * Updates window style in DOM
+   */
+  private _updateStyles;
 }
 /**
  * Window dimension definition
  */
 export type WindowDimension = {
-	/**
-	 * Width in pixels (or float for percentage in setters)
-	 */
-	width: number;
-	/**
-	 * Height in pixels (or float for percentage in setters)
-	 */
-	height: number;
+  /**
+   * Width in pixels (or float for percentage in setters)
+   */
+  width: number;
+  /**
+   * Height in pixels (or float for percentage in setters)
+   */
+  height: number;
 };
 /**
  * Window position definition
  */
 export type WindowPosition = {
-	/**
-	 * Left in pixels (or float for percentage in setters)
-	 */
-	left: number;
-	/**
-	 * Top in pixels (or float for percentage in setters)
-	 */
-	top: number;
+  /**
+   * Left in pixels (or float for percentage in setters)
+   */
+  left: number;
+  /**
+   * Top in pixels (or float for percentage in setters)
+   */
+  top: number;
 };
 /**
  * Window session
  */
 export type WindowSession = {
-	id: number;
-	maximized: boolean;
-	minimized: boolean;
-	position: WindowPosition;
-	dimension: WindowDimension;
+  id: number;
+  maximized: boolean;
+  minimized: boolean;
+  position: WindowPosition;
+  dimension: WindowDimension;
 };
 /**
  * Window attributes definition
  */
 export type WindowAttributes = {
-	/**
-	 * A list of class names
-	 */
-	classNames?: string[];
-	/**
-	 * If always on top
-	 */
-	ontop?: boolean;
-	/**
-	 * Gravity (center/top/left/right/bottom or any combination)
-	 */
-	gravity?: string;
-	/**
-	 * If resizable
-	 */
-	resizable?: boolean;
-	/**
-	 * If focusable
-	 */
-	focusable?: boolean;
-	/**
-	 * If window if maximizable
-	 */
-	maximizable?: boolean;
-	/**
-	 * If minimizable
-	 */
-	minimizable?: boolean;
-	/**
-	 * If moveable
-	 */
-	moveable?: boolean;
-	/**
-	 * If closeable
-	 */
-	closeable?: boolean;
-	/**
-	 * Show header
-	 */
-	header?: boolean;
-	/**
-	 * Show controls
-	 */
-	controls?: boolean;
-	/**
-	 * Global visibility, 'restricted' to hide from window lists etc.
-	 */
-	visibility?: string;
-	/**
-	 * Clamp the window position upon creation
-	 */
-	clamp?: boolean;
-	/**
-	 * If window should have the default drop action
-	 */
-	droppable?: boolean;
-	/**
-	 * Minimum dimension
-	 */
-	minDimension?: WindowDimension;
-	/**
-	 * Maximum dimension
-	 */
-	maxDimension?: WindowDimension;
-	/**
-	 * A map of matchMedia to name
-	 */
-	mediaQueries?: {
-		name: string;
-	};
+  /**
+   * A list of class names
+   */
+  classNames?: string[];
+  /**
+   * If always on top
+   */
+  ontop?: boolean;
+  /**
+   * Gravity (center/top/left/right/bottom or any combination)
+   */
+  gravity?: string;
+  /**
+   * If resizable
+   */
+  resizable?: boolean;
+  /**
+   * If focusable
+   */
+  focusable?: boolean;
+  /**
+   * If window if maximizable
+   */
+  maximizable?: boolean;
+  /**
+   * If minimizable
+   */
+  minimizable?: boolean;
+  /**
+   * If moveable
+   */
+  moveable?: boolean;
+  /**
+   * If closeable
+   */
+  closeable?: boolean;
+  /**
+   * Show header
+   */
+  header?: boolean;
+  /**
+   * Show controls
+   */
+  controls?: boolean;
+  /**
+   * Global visibility, 'restricted' to hide from window lists etc.
+   */
+  visibility?: string;
+  /**
+   * Clamp the window position upon creation
+   */
+  clamp?: boolean;
+  /**
+   * If window should have the default drop action
+   */
+  droppable?: boolean;
+  /**
+   * Minimum dimension
+   */
+  minDimension?: WindowDimension;
+  /**
+   * Maximum dimension
+   */
+  maxDimension?: WindowDimension;
+  /**
+   * A map of matchMedia to name
+   */
+  mediaQueries?: {
+    name: string;
+  };
 };
 /**
  * Window state definition
  */
 export type WindowState = {
-	/**
-	 * Title
-	 */
-	title: string;
-	/**
-	 * Icon
-	 */
-	icon: string;
-	/**
-	 * If moving
-	 */
-	moving?: boolean;
-	/**
-	 * If resizing
-	 */
-	resizing?: boolean;
-	/**
-	 * If loading
-	 */
-	loading?: boolean;
-	/**
-	 * If focused
-	 */
-	focused?: boolean;
-	/**
-	 * If maximized
-	 */
-	maximized?: boolean;
-	/**
-	 * If mimimized
-	 */
-	mimimized?: boolean;
-	/**
-	 * If modal to the parent
-	 */
-	modal?: boolean;
-	/**
-	 * The z-index (auto calculated)
-	 */
-	zIndex?: number;
-	/**
-	 * Position
-	 */
-	position?: WindowPosition;
-	/**
-	 * Dimension
-	 */
-	dimension?: WindowDimension;
+  /**
+   * Title
+   */
+  title: string;
+  /**
+   * Icon
+   */
+  icon: string;
+  /**
+   * If moving
+   */
+  moving?: boolean;
+  /**
+   * If resizing
+   */
+  resizing?: boolean;
+  /**
+   * If loading
+   */
+  loading?: boolean;
+  /**
+   * If focused
+   */
+  focused?: boolean;
+  /**
+   * If maximized
+   */
+  maximized?: boolean;
+  /**
+   * If mimimized
+   */
+  mimimized?: boolean;
+  /**
+   * If modal to the parent
+   */
+  modal?: boolean;
+  /**
+   * The z-index (auto calculated)
+   */
+  zIndex?: number;
+  /**
+   * Position
+   */
+  position?: WindowPosition;
+  /**
+   * Dimension
+   */
+  dimension?: WindowDimension;
 };
 /**
  * Window options definition
  */
 export type WindowOptions = {
-	/**
-	 * Window Id (not globaly unique)
-	 */
-	id: string;
-	/**
-	 * Window Title
-	 */
-	title?: string;
-	/**
-	 * Window Icon
-	 */
-	icon?: string;
-	/**
-	 * The parent Window reference
-	 */
-	parent?: Window;
-	/**
-	 * The Window HTML template (or function with signature (el, win) for programatic construction)
-	 */
-	template?: string | Function;
-	/**
-	 * A callback function when window destructs to interrupt the procedure
-	 */
-	ondestroy?: Function;
-	/**
-	 * Window position
-	 */
-	position?: WindowPosition | string;
-	/**
-	 * Window dimension
-	 */
-	dimension?: WindowDimension;
-	/**
-	 * Apply Window attributes
-	 */
-	attributes?: WindowAttributes;
-	/**
-	 * Apply Window state
-	 */
-	state?: WindowState;
+  /**
+   * Window Id (not globaly unique)
+   */
+  id: string;
+  /**
+   * Window Title
+   */
+  title?: string;
+  /**
+   * Window Icon
+   */
+  icon?: string;
+  /**
+   * The parent Window reference
+   */
+  parent?: Window;
+  /**
+   * The Window HTML template (or function with signature (el, win) for programatic construction)
+   */
+  template?: string | Function;
+  /**
+   * A callback function when window destructs to interrupt the procedure
+   */
+  ondestroy?: Function;
+  /**
+   * Window position
+   */
+  position?: WindowPosition | string;
+  /**
+   * Window dimension
+   */
+  dimension?: WindowDimension;
+  /**
+   * Apply Window attributes
+   */
+  attributes?: WindowAttributes;
+  /**
+   * Apply Window state
+   */
+  state?: WindowState;
 };
 declare class Application extends EventEmitter {
-	/**
-	 * Get a list of all running applications
-	 */
-	static getApplications(): Application[];
-	/**
-	 * Kills all running applications
-	 */
-	static destroyAll(): void;
-	/**
-	 * Create application
-	 */
-	constructor(core: Core, data: ApplicationData);
-	/**
-	 * The Application ID
-	 */
-	readonly pid: number;
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Application arguments
-	 */
-	args: {
-		foo: any;
-	};
-	/**
-	 * Application options
-	 */
-	options: ApplicationOptions;
-	/**
-	 * Application metadata
-	 */
-	readonly metadata: any;
-	/**
-	 * Window list
-	 */
-	windows: Window[];
-	/**
-	 * Worker instances
-	 */
-	workers: Worker[];
-	/**
-	 * Options for internal fetch/requests
-	 */
-	requestOptions: object;
-	/**
-	 * The application destruction state
-	 */
-	destroyed: boolean;
-	/**
-	 * Application settings
-	 */
-	settings: {
-		foo: any;
-	};
-	/**
-	 * Application started time
-	 */
-	readonly started: Date;
-	/**
-	 * Application WebSockets
-	 */
-	sockets: Websocket[];
-	/**
-	 * Destroy application
-	 */
-	destroy(remove?: boolean): void;
-	/**
-	 * Re-launch this application
-	 */
-	relaunch(): void;
-	/**
-	 * Gets a URI to a resource for this application
-	 * If given path is an URI it will just return itself.
-	 */
-	resource(path?: string, options?: object): string;
-	/**
-	 * Performs a request to the OS.js server with the application
-	 * as the endpoint.
-	 */
-	request(path?: string, options?: any, type?: string): Promise<any>;
-	/**
-	 * Creates a new Websocket
-	 */
-	socket(path?: string, options?: any): Websocket;
-	/**
-	 * Sends a message over websocket via the core connection.
-	 * This does not create a new connection, but rather uses the core connection.
-	 * For subscribing to messages from the server use the 'ws:message' event
-	 */
-	send(...args: any[]): void;
-	/**
-	 * Creates a new Worker
-	 */
-	worker(filename: string, options?: object): Worker;
-	/**
-	 * Create a new window belonging to this application
-	 */
-	createWindow(options?: any): Window;
-	/**
-	 * Removes window(s) based on given filter
-	 */
-	removeWindow(filter: Function): void;
-	/**
-	 * Gets a snapshot of the application session
-	 */
-	getSession(): ApplicationSession;
-	/**
-	 * Emits an event across all (or filtered) applications
-	 * @deprecated
-	 */
-	emitAll(filter?: Function): Function;
-	/**
-	 * Saves settings
-	 */
-	saveSettings(): Promise<boolean>;
+  /**
+   * Get a list of all running applications
+   */
+  static getApplications(): Application[];
+  /**
+   * Kills all running applications
+   */
+  static destroyAll(): void;
+  /**
+   * Create application
+   */
+  constructor(core: Core, data: ApplicationData);
+  /**
+   * The Application ID
+   */
+  readonly pid: number;
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Application arguments
+   */
+  args: {
+    foo: any;
+  };
+  /**
+   * Application options
+   */
+  options: ApplicationOptions;
+  /**
+   * Application metadata
+   */
+  readonly metadata: any;
+  /**
+   * Window list
+   */
+  windows: Window[];
+  /**
+   * Worker instances
+   */
+  workers: Worker[];
+  /**
+   * Options for internal fetch/requests
+   */
+  requestOptions: object;
+  /**
+   * The application destruction state
+   */
+  destroyed: boolean;
+  /**
+   * Application settings
+   */
+  settings: {
+    foo: any;
+  };
+  /**
+   * Application started time
+   */
+  readonly started: Date;
+  /**
+   * Application WebSockets
+   */
+  sockets: Websocket[];
+  /**
+   * Destroy application
+   */
+  destroy(remove?: boolean): void;
+  /**
+   * Re-launch this application
+   */
+  relaunch(): void;
+  /**
+   * Gets a URI to a resource for this application
+   * If given path is an URI it will just return itself.
+   */
+  resource(path?: string, options?: object): string;
+  /**
+   * Performs a request to the OS.js server with the application
+   * as the endpoint.
+   */
+  request(path?: string, options?: any, type?: string): Promise<any>;
+  /**
+   * Creates a new Websocket
+   */
+  socket(path?: string, options?: any): Websocket;
+  /**
+   * Sends a message over websocket via the core connection.
+   * This does not create a new connection, but rather uses the core connection.
+   * For subscribing to messages from the server use the 'ws:message' event
+   */
+  send(...args: any[]): void;
+  /**
+   * Creates a new Worker
+   */
+  worker(filename: string, options?: object): Worker;
+  /**
+   * Create a new window belonging to this application
+   */
+  createWindow(options?: any): Window;
+  /**
+   * Removes window(s) based on given filter
+   */
+  removeWindow(filter: Function): void;
+  /**
+   * Gets a snapshot of the application session
+   */
+  getSession(): ApplicationSession;
+  /**
+   * Emits an event across all (or filtered) applications
+   * @deprecated
+   */
+  emitAll(filter?: Function): Function;
+  /**
+   * Saves settings
+   */
+  saveSettings(): Promise<boolean>;
 }
 /**
  * Application Options
  */
 export type ApplicationOptions = {
-	/**
-	 * Initial settings
-	 */
-	settings?: object;
-	/**
-	 * Restore data
-	 */
-	restore?: object;
-	/**
-	 * Auto-focus first created window
-	 */
-	windowAutoFocus?: boolean;
-	/**
-	 * Allow session storage
-	 */
-	sessionable?: boolean;
+  /**
+   * Initial settings
+   */
+  settings?: object;
+  /**
+   * Restore data
+   */
+  restore?: object;
+  /**
+   * Auto-focus first created window
+   */
+  windowAutoFocus?: boolean;
+  /**
+   * Allow session storage
+   */
+  sessionable?: boolean;
 };
 /**
  * Application Data
  */
 export type ApplicationData = {
-	/**
-	 * Launch arguments
-	 */
-	args: {
-		foo: any;
-	};
-	/**
-	 * Options
-	 */
-	options?: ApplicationOptions;
-	/**
-	 * Package Metadata
-	 */
-	metadata?: any;
+  /**
+   * Launch arguments
+   */
+  args: {
+    foo: any;
+  };
+  /**
+   * Options
+   */
+  options?: ApplicationOptions;
+  /**
+   * Package Metadata
+   */
+  metadata?: any;
 };
 /**
  * Application Session
  */
 export type ApplicationSession = {
-	args: {
-		foo: string;
-	};
-	name: string;
-	windows: any[];
+  args: {
+    foo: string;
+  };
+  name: string;
+  windows: any[];
 };
 declare class Core extends CoreBase {
-	/**
-	 * Create core instance
-	 */
-	constructor(config?: any, options?: CoreOptions);
-	/**
-	 * Websocket connection
-	 */
-	ws: Websocket;
-	/**
-	 * Ping (stay alive) interval
-	 */
-	ping: number;
-	/**
-	 * Splash instance
-	 */
-	readonly splash: Splash;
-	/**
-	 * Main DOM element
-	 */
-	readonly $root: Element;
-	/**
-	 * Windows etc DOM element
-	 */
-	readonly $contents: Element;
-	/**
-	 * Resource script container DOM element
-	 */
-	readonly $resourceRoot: Element;
-	/**
-	 * Default fetch request options
-	 */
-	requestOptions: any;
-	/**
-	 * Url Resolver
-	 */
-	readonly urlResolver: () => string;
-	/**
-	 * Current user data
-	 */
-	readonly user: CoreUserData;
-	/**
-	 * Attaches some internal events
-	 */
-	private _attachEvents;
-	/**
-	 * Creates the main connection to server
-	 */
-	private _createConnection;
-	/**
-	 * Creates event listeners*
-	 */
-	private _createListeners;
-	/**
-	 * Creates an URL based on configured public path
-	 * If you give a options.type, the URL will be resolved
-	 * to the correct resource.
-	 */
-	url(endpoint?: string, options?: {
-		prefix: boolean;
-		type: string;
-	}, metadata?: any): string;
-	/**
-	 * Make a HTTP request
-	 * This is a wrapper for making a 'fetch' request with some helpers
-	 * and integration with OS.js
-	 */
-	request(url: string, options?: any, type?: string, force?: boolean): any;
-	/**
-	 * Create an application from a package
-	 */
-	run(name: string, args?: {
-		foo: any;
-	}, options?: any): Promise<Application>;
-	/**
-	 * Spawns an application based on the file given
-	 */
-	open(file: any, options?: any): boolean | Application;
-	/**
-	 * Wrapper method to create an application choice dialog
-	 */
-	private _openApplicationDialog;
-	/**
-	 * Sends a 'broadcast' event with given arguments
-	 * to all applications matching given filter
-	 */
-	broadcast(pkg: string | Function, name: string, ...args: any[]): string[];
-	/**
-	 * Sends a signal to the server over websocket.
-	 * This will be interpreted as an event in the server core.
-	*/
-	send(name:string, ...params: any[]);
-	/**
-	 * Set the internal fetch/request options
-	 */
-	setRequestOptions(options: object): void;
-	/**
-	 * Gets the current user
-	 */
-	getUser(): CoreUserData;
-	/**
-	 * Add middleware function to a group
-	 */
-	middleware(group: string, callback: Function): void;
+  /**
+   * Create core instance
+   */
+  constructor(config?: any, options?: CoreOptions);
+  /**
+   * Websocket connection
+   */
+  ws: Websocket;
+  /**
+   * Ping (stay alive) interval
+   */
+  ping: number;
+  /**
+   * Splash instance
+   */
+  readonly splash: Splash;
+  /**
+   * Main DOM element
+   */
+  readonly $root: Element;
+  /**
+   * Windows etc DOM element
+   */
+  readonly $contents: Element;
+  /**
+   * Resource script container DOM element
+   */
+  readonly $resourceRoot: Element;
+  /**
+   * Default fetch request options
+   */
+  requestOptions: any;
+  /**
+   * Url Resolver
+   */
+  readonly urlResolver: () => string;
+  /**
+   * Current user data
+   */
+  readonly user: CoreUserData;
+  /**
+   * Attaches some internal events
+   */
+  private _attachEvents;
+  /**
+   * Creates the main connection to server
+   */
+  private _createConnection;
+  /**
+   * Creates event listeners*
+   */
+  private _createListeners;
+  /**
+   * Creates an URL based on configured public path
+   * If you give a options.type, the URL will be resolved
+   * to the correct resource.
+   */
+  url(endpoint?: string, options?: {
+    prefix: boolean;
+    type: string;
+  }, metadata?: any): string;
+  /**
+   * Make a HTTP request
+   * This is a wrapper for making a 'fetch' request with some helpers
+   * and integration with OS.js
+   */
+  request(url: string, options?: any, type?: string, force?: boolean): any;
+  /**
+   * Create an application from a package
+   */
+  run(name: string, args?: {
+    foo: any;
+  }, options?: any): Promise<Application>;
+  /**
+   * Spawns an application based on the file given
+   */
+  open(file: any, options?: any): boolean | Application;
+  /**
+   * Wrapper method to create an application choice dialog
+   */
+  private _openApplicationDialog;
+  /**
+   * Sends a 'broadcast' event with given arguments
+   * to all applications matching given filter
+   */
+  broadcast(pkg: string | Function, name: string, ...args: any[]): string[];
+  /**
+   * Sends a signal to the server over websocket.
+   * This will be interpreted as an event in the server core.
+  */
+  send(name:string, ...params: any[]);
+  /**
+   * Set the internal fetch/request options
+   */
+  setRequestOptions(options: object): void;
+  /**
+   * Gets the current user
+   */
+  getUser(): CoreUserData;
+  /**
+   * Add middleware function to a group
+   */
+  middleware(group: string, callback: Function): void;
 }
 export type SplashCallback = (core: Core) => Splash;
 /**
  * User Data
  */
 export type CoreUserData = {
-	username: string;
-	id?: number;
-	groups?: string[];
+  username: string;
+  id?: number;
+  groups?: string[];
 };
 /**
  * Core Options
  */
 export type CoreOptions = {
-	/**
-	 * The root DOM element for elements
-	 */
-	root?: Element;
-	/**
-	 * The root DOM element for resources
-	 */
-	resourceRoot?: Element;
-	/**
-	 * List of class names to apply to root dom element
-	 */
-	classNames?: string[];
-	/**
-	 * Custom callback function for creating splash screen
-	 */
-	splash?: SplashCallback | Splash;
+  /**
+   * The root DOM element for elements
+   */
+  root?: Element;
+  /**
+   * The root DOM element for resources
+   */
+  resourceRoot?: Element;
+  /**
+   * List of class names to apply to root dom element
+   */
+  classNames?: string[];
+  /**
+   * Custom callback function for creating splash screen
+   */
+  splash?: SplashCallback | Splash;
 };
 declare class Search {
-	/**
-	 * Create Search instance
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Wired actions
-	 */
-	ui: any;
-	/**
-	 * Last focused window
-	 */
-	focusLastWindow: Window;
-	/**
-	 * Search root DOM element
-	 */
-	readonly $element: Element;
-	/**
-	 * Destroy Search instance
-	 */
-	destroy(): void;
-	/**
-	 * Initializes Search Service
-	 */
-	init(): void;
-	/**
-	 * Performs a search across all mounts
-	 */
-	search(pattern: string): Promise<any[]>;
-	/**
-	 * Focuses UI
-	 */
-	focus(): void;
-	/**
-	 * Hides UI
-	 */
-	hide(): void;
-	/**
-	 * Shows UI
-	 */
-	show(): void;
+  /**
+   * Create Search instance
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Wired actions
+   */
+  ui: any;
+  /**
+   * Last focused window
+   */
+  focusLastWindow: Window;
+  /**
+   * Search root DOM element
+   */
+  readonly $element: Element;
+  /**
+   * Destroy Search instance
+   */
+  destroy(): void;
+  /**
+   * Initializes Search Service
+   */
+  init(): void;
+  /**
+   * Performs a search across all mounts
+   */
+  search(pattern: string): Promise<any[]>;
+  /**
+   * Focuses UI
+   */
+  focus(): void;
+  /**
+   * Hides UI
+   */
+  hide(): void;
+  /**
+   * Shows UI
+   */
+  show(): void;
 }
 declare class DesktopIconView extends EventEmitter {
-	/**
-	 */
-	constructor(core: Core);
-	core: Core;
-	$root: HTMLDivElement;
-	iconview: any;
-	root: string;
-	destroy(): void;
-	_render(root: any): boolean;
-	render(root: any): void;
-	createFileContextMenu(ev: any, entry: any): void;
-	createDropContextMenu(ev: any, data: any, files: any): void;
-	createRootContextMenu(ev: any): void;
-	_createWatcher(): void;
-	applySettings(): void;
+  /**
+   */
+  constructor(core: Core);
+  core: Core;
+  $root: HTMLDivElement;
+  iconview: any;
+  root: string;
+  destroy(): void;
+  _render(root: any): boolean;
+  render(root: any): void;
+  createFileContextMenu(ev: any, entry: any): void;
+  createDropContextMenu(ev: any, data: any, files: any): void;
+  createRootContextMenu(ev: any): void;
+  _createWatcher(): void;
+  applySettings(): void;
 }
 declare class Desktop extends EventEmitter {
-	/**
-	 * Create Desktop
-	 */
-	constructor(core: Core, options?: any);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Desktop Options
-	 */
-	readonly options: DeskopOptions;
-	/**
-	 * Theme DOM elements
-	 */
-	$theme: Element[];
-	/**
-	 * Icon DOM elements
-	 */
-	$icons: Element[];
-	/**
-	 * Default context menu entries
-	 */
-	contextmenuEntries: DesktopContextMenuEntry[];
-	/**
-	 * Search instance
-	 */
-	readonly search: Search | null;
-	/**
-	 * Icon View instance
-	 */
-	readonly iconview: DesktopIconView;
-	/**
-	 * Keyboard context dom element
-	 */
-	keyboardContext: Element | null;
-	/**
-	 * Desktop subtraction rectangle
-	 */
-	subtract: DesktopViewportRectangle;
-	/**
-	 * Destroy Desktop
-	 */
-	destroy(): void;
-	/**
-	 * Initializes Desktop
-	 */
-	init(): void;
-	/**
-	 * Initializes connection events
-	 */
-	initConnectionEvents(): void;
-	/**
-	 * Initializes user interface events
-	 */
-	initUIEvents(): void;
-	/**
-	 * Initializes development tray icons
-	 */
-	initDeveloperTray(): void;
-	/**
-	 * Initializes drag-and-drop events
-	 */
-	initDragEvents(): void;
-	/**
-	 * Initializes keyboard events
-	 */
-	initKeyboardEvents(): void;
-	/**
-	 * Initializes global keyboard events
-	 */
-	initGlobalKeyboardEvents(): void;
-	/**
-	 * Initializes mouse events
-	 */
-	initMouseEvents(): void;
-	/**
-	 * Initializes base events
-	 */
-	initBaseEvents(): void;
-	/**
-	 * Initializes locales
-	 */
-	initLocales(): void;
-	/**
-	 * Starts desktop services
-	 */
-	start(): void;
-	/**
-	 * Update CSS
-	 */
-	private _updateCSS;
-	/**
-	 * Adds something to the default contextmenu entries
-	 */
-	addContextMenu(entries: DesktopContextMenuEntry[]): void;
-	/**
-	 * Applies settings and updates desktop
-	 */
-	applySettings(settings?: DesktopSettings): DesktopSettings;
-	/**
-	 * Removes current style theme from DOM
-	 */
-	private _removeTheme;
-	/**
-	 * Removes current icon theme from DOM
-	 */
-	private _removeIcons;
-	/**
-	 * Adds or removes the icon view
-	 */
-	applyIconView(settings: DesktopIconViewSettings): void;
-	/**
-	 * Sets the current icon theme from settings
-	 */
-	applyIcons(name: string): Promise<undefined>;
-	/**
-	 * Sets the current style theme from settings
-	 */
-	applyTheme(name: string): Promise<undefined>;
-	/**
-	 * Apply theme wrapper
-	 */
-	private _applyTheme;
-	/**
-	 * Apply settings by key
-	 */
-	private _applySettingsByKey;
-	/**
-	 * Create drop context menu entries
-	 */
-	createDropContextMenu(data: any): any[];
-	/**
-	 * When developer menu is shown
-	 */
-	onDeveloperMenu(ev: Event): void;
-	/**
-	 * When drop menu is shown
-	 */
-	onDropContextMenu(ev: Event, data: any): void;
-	/**
-	 * When context menu is shown
-	 */
-	onContextMenu(ev: Event): void;
-	/**
-	 * Sets the keyboard context.
-	 * Used for tabbing and other special events
-	 */
-	setKeyboardContext(ctx?: Element): void;
-	/**
-	 * Gets the rectangle of available space
-	 * This is based on any panels etc taking up space
-	 */
-	getRect(): DesktopViewportRectangle;
+  /**
+   * Create Desktop
+   */
+  constructor(core: Core, options?: any);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Desktop Options
+   */
+  readonly options: DeskopOptions;
+  /**
+   * Theme DOM elements
+   */
+  $theme: Element[];
+  /**
+   * Icon DOM elements
+   */
+  $icons: Element[];
+  /**
+   * Default context menu entries
+   */
+  contextmenuEntries: DesktopContextMenuEntry[];
+  /**
+   * Search instance
+   */
+  readonly search: Search | null;
+  /**
+   * Icon View instance
+   */
+  readonly iconview: DesktopIconView;
+  /**
+   * Keyboard context dom element
+   */
+  keyboardContext: Element | null;
+  /**
+   * Desktop subtraction rectangle
+   */
+  subtract: DesktopViewportRectangle;
+  /**
+   * Destroy Desktop
+   */
+  destroy(): void;
+  /**
+   * Initializes Desktop
+   */
+  init(): void;
+  /**
+   * Initializes connection events
+   */
+  initConnectionEvents(): void;
+  /**
+   * Initializes user interface events
+   */
+  initUIEvents(): void;
+  /**
+   * Initializes development tray icons
+   */
+  initDeveloperTray(): void;
+  /**
+   * Initializes drag-and-drop events
+   */
+  initDragEvents(): void;
+  /**
+   * Initializes keyboard events
+   */
+  initKeyboardEvents(): void;
+  /**
+   * Initializes global keyboard events
+   */
+  initGlobalKeyboardEvents(): void;
+  /**
+   * Initializes mouse events
+   */
+  initMouseEvents(): void;
+  /**
+   * Initializes base events
+   */
+  initBaseEvents(): void;
+  /**
+   * Initializes locales
+   */
+  initLocales(): void;
+  /**
+   * Starts desktop services
+   */
+  start(): void;
+  /**
+   * Update CSS
+   */
+  private _updateCSS;
+  /**
+   * Adds something to the default contextmenu entries
+   */
+  addContextMenu(entries: DesktopContextMenuEntry[]): void;
+  /**
+   * Applies settings and updates desktop
+   */
+  applySettings(settings?: DesktopSettings): DesktopSettings;
+  /**
+   * Removes current style theme from DOM
+   */
+  private _removeTheme;
+  /**
+   * Removes current icon theme from DOM
+   */
+  private _removeIcons;
+  /**
+   * Adds or removes the icon view
+   */
+  applyIconView(settings: DesktopIconViewSettings): void;
+  /**
+   * Sets the current icon theme from settings
+   */
+  applyIcons(name: string): Promise<undefined>;
+  /**
+   * Sets the current style theme from settings
+   */
+  applyTheme(name: string): Promise<undefined>;
+  /**
+   * Apply theme wrapper
+   */
+  private _applyTheme;
+  /**
+   * Apply settings by key
+   */
+  private _applySettingsByKey;
+  /**
+   * Create drop context menu entries
+   */
+  createDropContextMenu(data: any): any[];
+  /**
+   * When developer menu is shown
+   */
+  onDeveloperMenu(ev: Event): void;
+  /**
+   * When drop menu is shown
+   */
+  onDropContextMenu(ev: Event, data: any): void;
+  /**
+   * When context menu is shown
+   */
+  onContextMenu(ev: Event): void;
+  /**
+   * Sets the keyboard context.
+   * Used for tabbing and other special events
+   */
+  setKeyboardContext(ctx?: Element): void;
+  /**
+   * Gets the rectangle of available space
+   * This is based on any panels etc taking up space
+   */
+  getRect(): DesktopViewportRectangle;
 }
 /**
  */
@@ -1221,256 +1221,256 @@ export type DesktopIconViewSettings = any;
 /**
  */
 export type DesktopSettings = {
-	iconview?: DesktopIconViewSettings;
+  iconview?: DesktopIconViewSettings;
 };
 /**
  * Desktop Options
  */
 export type DeskopOptions = {
-	/**
-	 * Default Context menu items
-	 */
-	contextmenu?: object[];
+  /**
+   * Default Context menu items
+   */
+  contextmenu?: object[];
 };
 /**
  * Desktop Viewport Rectangle
  */
 export type DesktopViewportRectangle = {
-	left: number;
-	top: number;
-	right: number;
-	bottom: number;
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
 };
 declare class Notification {
-	/**
-	 * Create notification
-	 */
-	constructor(core: Core, root: Element, options?: NotificationOptions);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Root node reference
-	 */
-	readonly $root: Element;
-	/**
-	 * Notification DOM node
-	 */
-	readonly $element: Element;
-	/**
-	 * The notification destruction state
-	 */
-	readonly destroyed: boolean;
-	/**
-	 * Options
-	 */
-	readonly options: NotificationOptions;
-	/**
-	 * Destroy notification
-	 */
-	destroy(): void;
-	/**
-	 * Render notification
-	 */
-	render(): Promise<boolean>;
+  /**
+   * Create notification
+   */
+  constructor(core: Core, root: Element, options?: NotificationOptions);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Root node reference
+   */
+  readonly $root: Element;
+  /**
+   * Notification DOM node
+   */
+  readonly $element: Element;
+  /**
+   * The notification destruction state
+   */
+  readonly destroyed: boolean;
+  /**
+   * Options
+   */
+  readonly options: NotificationOptions;
+  /**
+   * Destroy notification
+   */
+  destroy(): void;
+  /**
+   * Render notification
+   */
+  render(): Promise<boolean>;
 }
 /**
  * Notification Options
  */
 export type NotificationOptions = {
-	/**
-	 * Title
-	 */
-	title: string;
-	/**
-	 * Message
-	 */
-	message: string;
-	/**
-	 * Sound to play
-	 */
-	sound?: string;
-	/**
-	 * Icon source
-	 */
-	icon?: string;
-	/**
-	 * Timeout value (0=infinite)
-	 */
-	timeout?: number;
-	/**
-	 * Adds a DOM class name to notification
-	 */
-	className?: string;
+  /**
+   * Title
+   */
+  title: string;
+  /**
+   * Message
+   */
+  message: string;
+  /**
+   * Sound to play
+   */
+  sound?: string;
+  /**
+   * Icon source
+   */
+  icon?: string;
+  /**
+   * Timeout value (0=infinite)
+   */
+  timeout?: number;
+  /**
+   * Adds a DOM class name to notification
+   */
+  className?: string;
 };
 declare class Notifications {
-	/**
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 */
-	$element: Element;
-	/**
-	 * Destroy notification handler
-	 */
-	destroy(): void;
-	/**
-	 * Initialize notification handler
-	 */
-	init(): void;
-	/**
-	 * Create a new notification
-	 */
-	create(options: NotificationOptions): Notification;
-	/**
-	 * Sets the element styles
-	 */
-	setElementStyles(): void;
-	/**
-	 * Creates a new CSS style object
-	 */
-	createElementStyles(): {
-		property: string;
-	};
+  /**
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   */
+  $element: Element;
+  /**
+   * Destroy notification handler
+   */
+  destroy(): void;
+  /**
+   * Initialize notification handler
+   */
+  init(): void;
+  /**
+   * Create a new notification
+   */
+  create(options: NotificationOptions): Notification;
+  /**
+   * Sets the element styles
+   */
+  setElementStyles(): void;
+  /**
+   * Creates a new CSS style object
+   */
+  createElementStyles(): {
+    property: string;
+  };
 }
 declare class WindowBehavior {
-	/**
-	 * Create window behavior
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Last action
-	 */
-	lastAction: string;
-	/**
-	 * LoFi DOM Element
-	 */
-	readonly $lofi: Element;
-	/**
-	 * Initializes window behavior
-	 */
-	init(win: Window): void;
-	/**
-	 * Handles Mouse Click Event
-	 */
-	click(ev: Event, win: Window): void;
-	/**
-	 * Handles Mouse Double Click Event
-	 */
-	dblclick(ev: Event, win: Window): void;
-	/**
-	 * Handles Mouse Down Event
-	 */
-	mousedown(ev: Event, win: Window): void;
-	/**
-	 * Handles Icon Double Click Event
-	 */
-	iconDblclick(ev: Event, win: Window): void;
-	/**
-	 * Handles Icon Click Event
-	 */
-	iconClick(ev: Event, win: Window): void;
+  /**
+   * Create window behavior
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Last action
+   */
+  lastAction: string;
+  /**
+   * LoFi DOM Element
+   */
+  readonly $lofi: Element;
+  /**
+   * Initializes window behavior
+   */
+  init(win: Window): void;
+  /**
+   * Handles Mouse Click Event
+   */
+  click(ev: Event, win: Window): void;
+  /**
+   * Handles Mouse Double Click Event
+   */
+  dblclick(ev: Event, win: Window): void;
+  /**
+   * Handles Mouse Down Event
+   */
+  mousedown(ev: Event, win: Window): void;
+  /**
+   * Handles Icon Double Click Event
+   */
+  iconDblclick(ev: Event, win: Window): void;
+  /**
+   * Handles Icon Click Event
+   */
+  iconClick(ev: Event, win: Window): void;
 }
 declare class Login extends EventEmitter {
-	/**
-	 * Create authentication handler
-	 */
-	constructor(core: Core, options?: LoginOptions);
-	/**
-	 * Login root DOM element
-	 */
-	$container: Element;
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Login options
-	 */
-	readonly options: any;
-	/**
-	 * Initializes the UI
-	 */
-	init(startHidden: any): void;
-	/**
-	 * Destroys the UI
-	 */
-	destroy(): void;
-	/**
-	 * Renders the UI
-	 */
-	render(startHidden: any): void;
+  /**
+   * Create authentication handler
+   */
+  constructor(core: Core, options?: LoginOptions);
+  /**
+   * Login root DOM element
+   */
+  $container: Element;
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Login options
+   */
+  readonly options: any;
+  /**
+   * Initializes the UI
+   */
+  init(startHidden: any): void;
+  /**
+   * Destroys the UI
+   */
+  destroy(): void;
+  /**
+   * Renders the UI
+   */
+  render(startHidden: any): void;
 }
 /**
  * Login Options
  */
 export type LoginOptions = {
-	/**
-	 * Title
-	 */
-	title?: string;
-	/**
-	 * Fields
-	 */
-	fields?: object[];
+  /**
+   * Title
+   */
+  title?: string;
+  /**
+   * Fields
+   */
+  fields?: object[];
 };
 declare class Auth {
-	/**
-	 */
-	constructor(core: Core, options?: AuthSettings);
-	/**
-	 * Authentication UI
-	 */
-	readonly ui: Login;
-	/**
-	 * Authentication adapter
-	 */
-	readonly adapter: AuthAdapter;
-	/**
-	 * Authentication callback function
-	 */
-	readonly callback: AuthCallback;
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Initializes authentication handler
-	 */
-	init(): any;
-	/**
-	 * Destroy authentication handler
-	 */
-	destroy(): void;
-	/**
-	 * Run the shutdown procedure
-	 */
-	shutdown(reload?: boolean): void;
-	/**
-	 * Shows Login UI
-	 */
-	show(cb: AuthCallback): Promise<boolean>;
-	/**
-	 * Performs a login
-	 */
-	login(values: AuthForm): Promise<boolean>;
-	/**
-	 * Performs a logout
-	 */
-	logout(reload?: boolean): Promise<boolean>;
-	/**
-	 * Performs a register call
-	 */
-	register(values: AuthForm): Promise<any>;
+  /**
+   */
+  constructor(core: Core, options?: AuthSettings);
+  /**
+   * Authentication UI
+   */
+  readonly ui: Login;
+  /**
+   * Authentication adapter
+   */
+  readonly adapter: AuthAdapter;
+  /**
+   * Authentication callback function
+   */
+  readonly callback: AuthCallback;
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Initializes authentication handler
+   */
+  init(): any;
+  /**
+   * Destroy authentication handler
+   */
+  destroy(): void;
+  /**
+   * Run the shutdown procedure
+   */
+  shutdown(reload?: boolean): void;
+  /**
+   * Shows Login UI
+   */
+  show(cb: AuthCallback): Promise<boolean>;
+  /**
+   * Performs a login
+   */
+  login(values: AuthForm): Promise<boolean>;
+  /**
+   * Performs a logout
+   */
+  logout(reload?: boolean): Promise<boolean>;
+  /**
+   * Performs a register call
+   */
+  register(values: AuthForm): Promise<any>;
 }
 /**
  */
@@ -1479,881 +1479,881 @@ export type AuthAdapter = any;
  */
 export type AuthAdapterConfig = any;
 export type AuthForm = {
-	username?: string;
-	password?: string;
+  username?: string;
+  password?: string;
 };
 export type AuthAdapterCallback = (core: Core) => AuthAdapter;
 export type LoginAdapterCallback = (core: Core) => Login;
 export type AuthCallback = (data: AuthForm) => boolean;
 export type AuthSettings = {
-	/**
-	 * Adapter to use
-	 */
-	adapter?: AuthAdapterCallback | AuthAdapter;
-	/**
-	 * Login Adapter to use
-	 */
-	login?: LoginAdapterCallback | Login;
-	/**
-	 * Adapter configuration
-	 */
-	config?: AuthAdapterConfig;
+  /**
+   * Adapter to use
+   */
+  adapter?: AuthAdapterCallback | AuthAdapter;
+  /**
+   * Login Adapter to use
+   */
+  login?: LoginAdapterCallback | Login;
+  /**
+   * Adapter configuration
+   */
+  config?: AuthAdapterConfig;
 };
 declare class Session {
-	/**
-	 * Creates the Session Handler
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Destroys instance
-	 */
-	destroy(): void;
-	/**
-	 * Saves session
-	 */
-	save(): Promise<boolean>;
-	/**
-	 * Loads session
-	 */
-	load(fresh?: boolean): Promise<boolean>;
+  /**
+   * Creates the Session Handler
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Destroys instance
+   */
+  destroy(): void;
+  /**
+   * Saves session
+   */
+  save(): Promise<boolean>;
+  /**
+   * Loads session
+   */
+  load(fresh?: boolean): Promise<boolean>;
 }
 declare class Tray {
-	/**
-	 * Creates the Tray Handler
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * All Tray entries
-	 */
-	entries: TrayEntry[];
-	/**
-	 * Destroys instance
-	 */
-	destroy(): void;
-	/**
-	 * Creates a new Tray entry
-	 */
-	create(options: TrayEntryData, handler?: Function): TrayEntry;
-	/**
-	 * Removes a Tray entry
-	 */
-	remove(entry: TrayEntry): void;
-	/**
-	 */
-	list(): TrayEntry[];
+  /**
+   * Creates the Tray Handler
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * All Tray entries
+   */
+  entries: TrayEntry[];
+  /**
+   * Destroys instance
+   */
+  destroy(): void;
+  /**
+   * Creates a new Tray entry
+   */
+  create(options: TrayEntryData, handler?: Function): TrayEntry;
+  /**
+   * Removes a Tray entry
+   */
+  remove(entry: TrayEntry): void;
+  /**
+   */
+  list(): TrayEntry[];
 
-	/**
-	 */
-	has(key): boolean;
+  /**
+   */
+  has(key): boolean;
 }
 /**
  * Tray Icon Data
  */
 export type TrayEntryData = {
-	/**
-	 * Icon source
-	 */
-	icon?: string;
-	/**
-	 * The title and tooltip
-	 */
-	title?: string;
-	/**
-	 * The callback function for clicks
-	 */
-	onclick?: Function;
-	/**
-	 * The callback function for contextmenu
-	 */
-	oncontextmenu?: Function;
+  /**
+   * Icon source
+   */
+  icon?: string;
+  /**
+   * The title and tooltip
+   */
+  title?: string;
+  /**
+   * The callback function for clicks
+   */
+  onclick?: Function;
+  /**
+   * The callback function for contextmenu
+   */
+  oncontextmenu?: Function;
 };
 /**
  * Tray Icon Entry
  */
 export type TrayEntry = {
-	/**
-	 * The given entry data
-	 */
-	entry: TrayEntryData;
-	/**
-	 * Updates entry with given data
-	 */
-	update: Function;
-	/**
-	 * Destroy the entry
-	 */
-	destroy: Function;
+  /**
+   * The given entry data
+   */
+  entry: TrayEntryData;
+  /**
+   * Updates entry with given data
+   */
+  update: Function;
+  /**
+   * Destroy the entry
+   */
+  destroy: Function;
 };
 declare class Preloader {
-	constructor(root: any);
-	/**
-	 * A list of cached preloads
-	 */
-	loaded: string[];
-	/**
-	 */
-	$root: Element;
-	destroy(): void;
-	/**
-	 * Loads all resources required for a package
-	 */
-	load(list: string[], force?: boolean): Promise<PreloaderResult>;
-	/**
-	 * Checks the loaded list
-	 */
-	private _load;
+  constructor(root: any);
+  /**
+   * A list of cached preloads
+   */
+  loaded: string[];
+  /**
+   */
+  $root: Element;
+  destroy(): void;
+  /**
+   * Loads all resources required for a package
+   */
+  load(list: string[], force?: boolean): Promise<PreloaderResult>;
+  /**
+   * Checks the loaded list
+   */
+  private _load;
 }
 export type PreloaderEntryElement = HTMLScriptElement | HTMLLinkElement;
 export type PreloaderResult = {
-	errors: string[];
-	elements: {
-		string: PreloaderEntryElement;
-	};
+  errors: string[];
+  elements: {
+    string: PreloaderEntryElement;
+  };
 };
 declare class Packages {
-	/**
-	 * Create package manage
-	 */
-	constructor(core: Core);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * A list of registered packages
-	 */
-	packages: PackageReference[];
-	/**
-	 * The lost of loaded package metadata
-	 */
-	metadata: PackageMetadata[];
-	/**
-	 * A list of running application names
-	 * Mainly used for singleton awareness
-	 */
-	private _running;
-	/**
-	 * Preloader
-	 */
-	readonly preloader: Preloader;
-	/**
-	 * If inited
-	 */
-	inited: boolean;
-	/**
-	 * Destroy package manager
-	 */
-	destroy(): void;
-	/**
-	 * Initializes package manager
-	 */
-	init(): Promise<boolean>;
-	/**
-	 * Launches a (application) package
-	 */
-	launch(name: string, args?: {
-		foo: any;
-	}, options?: PackageLaunchOptions): Promise<Application>;
-	/**
-	 * Launches an application package
-	 */
-	private _launchApplication;
-	/**
-	 * Launches a (theme) package
-	 */
-	private _launchTheme;
-	/**
-	 * Wrapper for launching a (application) package
-	 */
-	private _launch;
-	/**
-	 * Autostarts tagged packages
-	 */
-	private _autostart;
-	/**
-	 * Registers a package
-	 */
-	register(name: string, callback: Function): void;
-	/**
-	 * Adds a set of packages
-	 */
-	addPackages(list: PackageMetadata[]): PackageMetadata[];
-	/**
-	 * Gets a list of packages (metadata)
-	 */
-	getPackages(filter?: Function): PackageMetadata[];
-	/**
-	 * Gets a list of packages compatible with the given mime type
-	 */
-	getCompatiblePackages(mimeType: string): PackageMetadata[];
-	/**
-	 * Gets a list of running packages
-	 */
-	running(): string[];
+  /**
+   * Create package manage
+   */
+  constructor(core: Core);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * A list of registered packages
+   */
+  packages: PackageReference[];
+  /**
+   * The lost of loaded package metadata
+   */
+  metadata: PackageMetadata[];
+  /**
+   * A list of running application names
+   * Mainly used for singleton awareness
+   */
+  private _running;
+  /**
+   * Preloader
+   */
+  readonly preloader: Preloader;
+  /**
+   * If inited
+   */
+  inited: boolean;
+  /**
+   * Destroy package manager
+   */
+  destroy(): void;
+  /**
+   * Initializes package manager
+   */
+  init(): Promise<boolean>;
+  /**
+   * Launches a (application) package
+   */
+  launch(name: string, args?: {
+    foo: any;
+  }, options?: PackageLaunchOptions): Promise<Application>;
+  /**
+   * Launches an application package
+   */
+  private _launchApplication;
+  /**
+   * Launches a (theme) package
+   */
+  private _launchTheme;
+  /**
+   * Wrapper for launching a (application) package
+   */
+  private _launch;
+  /**
+   * Autostarts tagged packages
+   */
+  private _autostart;
+  /**
+   * Registers a package
+   */
+  register(name: string, callback: Function): void;
+  /**
+   * Adds a set of packages
+   */
+  addPackages(list: PackageMetadata[]): PackageMetadata[];
+  /**
+   * Gets a list of packages (metadata)
+   */
+  getPackages(filter?: Function): PackageMetadata[];
+  /**
+   * Gets a list of packages compatible with the given mime type
+   */
+  getCompatiblePackages(mimeType: string): PackageMetadata[];
+  /**
+   * Gets a list of running packages
+   */
+  running(): string[];
 }
 /**
  * A registered package reference
  */
 export type PackageReference = {
-	/**
-	 * Package metadata
-	 */
-	metadata: PackageMetadata;
-	/**
-	 * Callback to instanciate
-	 */
-	callback: Function;
+  /**
+   * Package metadata
+   */
+  metadata: PackageMetadata;
+  /**
+   * Callback to instanciate
+   */
+  callback: Function;
 };
 /**
  * A package metadata
  */
 export type PackageMetadata = {
-	/**
-	 * The package name
-	 */
-	name: string;
-	/**
-	 * Package category
-	 */
-	category?: string;
-	/**
-	 * Package icon
-	 */
-	icon?: string;
-	/**
-	 * If only one instance allowed
-	 */
-	singleton?: boolean;
-	/**
-	 * Autostart on boot
-	 */
-	autostart?: boolean;
-	/**
-	 * Hide from launch menus etc.
-	 */
-	hidden?: boolean;
-	/**
-	 * Server script filename
-	 */
-	server?: string;
-	/**
-	 * Only available for users in this group
-	 */
-	groups?: string[];
-	/**
-	 * Files to preload
-	 */
-	files?: Array<object | string>;
-	/**
-	 * A map of locales and titles
-	 */
-	title: {
-		key: string;
-	};
-	/**
-	 * A map of locales and titles
-	 */
-	description: {
-		key: string;
-	};
+  /**
+   * The package name
+   */
+  name: string;
+  /**
+   * Package category
+   */
+  category?: string;
+  /**
+   * Package icon
+   */
+  icon?: string;
+  /**
+   * If only one instance allowed
+   */
+  singleton?: boolean;
+  /**
+   * Autostart on boot
+   */
+  autostart?: boolean;
+  /**
+   * Hide from launch menus etc.
+   */
+  hidden?: boolean;
+  /**
+   * Server script filename
+   */
+  server?: string;
+  /**
+   * Only available for users in this group
+   */
+  groups?: string[];
+  /**
+   * Files to preload
+   */
+  files?: Array<object | string>;
+  /**
+   * A map of locales and titles
+   */
+  title: {
+    key: string;
+  };
+  /**
+   * A map of locales and titles
+   */
+  description: {
+    key: string;
+  };
 };
 /**
  * Package Launch Options
  */
 export type PackageLaunchOptions = {
-	/**
-	 * Force preload reloading
-	 */
-	forcePreload?: boolean;
+  /**
+   * Force preload reloading
+   */
+  forcePreload?: boolean;
 };
 declare class Clipboard {
-	/**
-	 */
-	clipboard: ClipboardData;
-	/**
-	 * Destroy clipboard
-	 */
-	destroy(): void;
-	/**
-	 * Clear clipboard
-	 */
-	clear(): void;
-	/**
-	 * Set clipboard data
-	 */
-	set(data: any, type?: string): void;
-	/**
-	 * Checks if current clipboard data has this type
-	 */
-	has(type: string | RegExp): boolean;
-	/**
-	 * Gets clipboard data
-	 */
-	get(clear?: boolean): Promise<any>;
+  /**
+   */
+  clipboard: ClipboardData;
+  /**
+   * Destroy clipboard
+   */
+  destroy(): void;
+  /**
+   * Clear clipboard
+   */
+  clear(): void;
+  /**
+   * Set clipboard data
+   */
+  set(data: any, type?: string): void;
+  /**
+   * Checks if current clipboard data has this type
+   */
+  has(type: string | RegExp): boolean;
+  /**
+   * Gets clipboard data
+   */
+  get(clear?: boolean): Promise<any>;
 }
 /**
  * Clipboard Data
  */
 export type ClipboardData = {
-	/**
-	 * Optional data type
-	 */
-	type?: string;
-	data: any;
+  /**
+   * Optional data type
+   */
+  type?: string;
+  data: any;
 };
 declare class Middleware {
-	/**
-	 */
-	middleware: MiddlewareData;
-	/**
-	 * Destroy middleware
-	 */
-	destroy(): void;
-	/**
-	 * Clear middleware
-	 */
-	clear(): void;
-	/**
-	 * Add middleware function to a group
-	 */
-	add(group: string, callback: Function): void;
-	/**
-	 * Remove middleware function from a group
-	 */
-	remove(group: string, callback: Function): void;
-	/**
-	 * Gets middleware functions for a group
-	 */
-	get(group: string): Function[];
+  /**
+   */
+  middleware: MiddlewareData;
+  /**
+   * Destroy middleware
+   */
+  destroy(): void;
+  /**
+   * Clear middleware
+   */
+  clear(): void;
+  /**
+   * Add middleware function to a group
+   */
+  add(group: string, callback: Function): void;
+  /**
+   * Remove middleware function from a group
+   */
+  remove(group: string, callback: Function): void;
+  /**
+   * Gets middleware functions for a group
+   */
+  get(group: string): Function[];
 }
 /**
  * Middleware Data
  */
 export type MiddlewareData = {
-	[group: string]: Function[]
+  [group: string]: Function[]
 };
 declare class CoreServiceProvider extends ServiceProvider {
-	/**
-	 */
-	constructor(core: Core, options?: CoreProviderOptions);
-	/**
-	 */
-	readonly session: Session;
-	/**
-	 */
-	readonly tray: Tray;
-	/**
-	 */
-	readonly pm: Packages;
-	/**
-	 */
-	readonly clipboard: Clipboard;
-	/**
-	 */
-	readonly middleware: Middleware;
-	/**
-	 * Registers contracts
-	 */
-	registerContracts(): void;
-	/**
-	 * Expose some internals to global
-	 */
-	createGlobalApi(): Readonly<{
-		make: (name: any, ...args: any[]) => any;
-		register: (name: any, callback: any) => void;
-		url: (endpoint: any, options: any, metadata: any) => any;
-		run: (name: any, args?: {}, options?: {}) => any;
-		open: (file: any, options?: {}) => any;
-		request: (url: any, options: any, type: any) => any;
-	}>;
-	/**
-	 * Event when dist changes from a build or deployment
-	 */
-	private _onDistChanged;
-	/**
-	 * Event when package dist changes from a build or deployment
-	 */
-	private _onPackageChanged;
-	/**
-	 * Provides localization contract
-	 */
-	createLocaleContract(): CoreProviderLocaleContract;
-	/**
-	 * Provides window contract
-	 */
-	createWindowContract(): CoreProviderWindowContract;
-	/**
-	 * Provides DnD contract
-	 */
-	createDnDContract(): CoreProviderDnDContract;
-	/**
-	 * Provides DOM contract
-	 */
-	createDOMContract(): CoreProviderDOMContract;
-	/**
-	 * Provides Theme contract
-	 */
-	createThemeContract(): CoreProviderThemeContract;
-	/**
-	 * Provides Sounds contract
-	 */
-	createSoundsContract(): CoreProviderSoundContract;
-	/**
-	 * Provides Session contract
-	 */
-	createSessionContract(): CoreProviderSessionContract;
-	/**
-	 * Provides Packages contract
-	 */
-	createPackagesContract(): CoreProviderPackagesContract;
-	/**
-	 * Provides Clipboard contract
-	 */
-	createClipboardContract(): CoreProviderClipboardContract;
-	/**
-	 * Provides Middleware contract
-	 */
-	createMiddlewareContract(): CoreProviderMiddlewareContract;
-	/**
-	 * Provides Tray contract
-	 */
-	createTrayContract(): CoreProviderTrayContract;
+  /**
+   */
+  constructor(core: Core, options?: CoreProviderOptions);
+  /**
+   */
+  readonly session: Session;
+  /**
+   */
+  readonly tray: Tray;
+  /**
+   */
+  readonly pm: Packages;
+  /**
+   */
+  readonly clipboard: Clipboard;
+  /**
+   */
+  readonly middleware: Middleware;
+  /**
+   * Registers contracts
+   */
+  registerContracts(): void;
+  /**
+   * Expose some internals to global
+   */
+  createGlobalApi(): Readonly<{
+    make: (name: any, ...args: any[]) => any;
+    register: (name: any, callback: any) => void;
+    url: (endpoint: any, options: any, metadata: any) => any;
+    run: (name: any, args?: {}, options?: {}) => any;
+    open: (file: any, options?: {}) => any;
+    request: (url: any, options: any, type: any) => any;
+  }>;
+  /**
+   * Event when dist changes from a build or deployment
+   */
+  private _onDistChanged;
+  /**
+   * Event when package dist changes from a build or deployment
+   */
+  private _onPackageChanged;
+  /**
+   * Provides localization contract
+   */
+  createLocaleContract(): CoreProviderLocaleContract;
+  /**
+   * Provides window contract
+   */
+  createWindowContract(): CoreProviderWindowContract;
+  /**
+   * Provides DnD contract
+   */
+  createDnDContract(): CoreProviderDnDContract;
+  /**
+   * Provides DOM contract
+   */
+  createDOMContract(): CoreProviderDOMContract;
+  /**
+   * Provides Theme contract
+   */
+  createThemeContract(): CoreProviderThemeContract;
+  /**
+   * Provides Sounds contract
+   */
+  createSoundsContract(): CoreProviderSoundContract;
+  /**
+   * Provides Session contract
+   */
+  createSessionContract(): CoreProviderSessionContract;
+  /**
+   * Provides Packages contract
+   */
+  createPackagesContract(): CoreProviderPackagesContract;
+  /**
+   * Provides Clipboard contract
+   */
+  createClipboardContract(): CoreProviderClipboardContract;
+  /**
+   * Provides Middleware contract
+   */
+  createMiddlewareContract(): CoreProviderMiddlewareContract;
+  /**
+   * Provides Tray contract
+   */
+  createTrayContract(): CoreProviderTrayContract;
 }
 /**
  * Core Provider Locale Contract
  */
 export type CoreProviderLocaleContract = {
-	format: Function;
-	translate: Function;
-	translatable: Function;
-	translatableFlat: Function;
-	getLocale: Function;
-	setLocale: Function;
+  format: Function;
+  translate: Function;
+  translatable: Function;
+  translatableFlat: Function;
+  getLocale: Function;
+  setLocale: Function;
 };
 /**
  * Core Provider Window Contract
  */
 export type CoreProviderWindowContract = {
-	create: Function;
-	list: Function;
-	last: Function;
+  create: Function;
+  list: Function;
+  last: Function;
 };
 /**
  * Core Provider DnD Contract
  */
 export type CoreProviderDnDContract = {
-	draggable: Function;
-	droppable: Function;
+  draggable: Function;
+  droppable: Function;
 };
 /**
  * Core Provider Theme Contract
  */
 export type CoreProviderDOMContract = {
-	script: Function;
-	style: Function;
+  script: Function;
+  style: Function;
 };
 /**
  * Core Provider Theme Contract
  */
 export type CoreProviderThemeContract = {
-	resource: Function;
-	icon: Function;
+  resource: Function;
+  icon: Function;
 };
 /**
  * Core Provider Sound Contract
  */
 export type CoreProviderSoundContract = {
-	resource: Function;
-	play: Function;
+  resource: Function;
+  play: Function;
 };
 /**
  * Core Provider Session Contract
  */
 export type CoreProviderSessionContract = {
-	save: Function;
-	load: Function;
+  save: Function;
+  load: Function;
 };
 /**
  * Core Provider Packages Contract
  */
 export type CoreProviderPackagesContract = {
-	launch?: Function;
-	register?: Function;
-	addPackages?: Function;
-	getPackages?: Function;
-	getCompatiblePackages?: Function;
-	running?: Function;
-	getMetadataFromName?: Function;
+  launch?: Function;
+  register?: Function;
+  addPackages?: Function;
+  getPackages?: Function;
+  getCompatiblePackages?: Function;
+  running?: Function;
+  getMetadataFromName?: Function;
 };
 /**
  * Core Provider Clipboard Contract
  */
 export type CoreProviderClipboardContract = {
-	clear?: Function;
-	set?: Function;
-	has?: Function;
-	get?: Function;
+  clear?: Function;
+  set?: Function;
+  has?: Function;
+  get?: Function;
 };
 /**
  * Core Provider Middleware Contract
  */
 export type CoreProviderMiddlewareContract = {
-	add: Function;
-	get: Function;
+  add: Function;
+  get: Function;
 };
 /**
  * Core Provider Tray Contract
  */
 export type CoreProviderTrayContract = {
-	create?: Function;
-	remove?: Function;
-	list?: TrayEntry[],
-	has?: boolean;
+  create?: Function;
+  remove?: Function;
+  list?: TrayEntry[],
+  has?: boolean;
 
 };
 /**
  * Core Provider Options
  */
 export type CoreProviderOptions = {
-	/**
-	 * Custom Window Behavior
-	 */
-	windowBehavior?: Function;
-	/**
-	 * Override locales
-	 */
-	locales?: any;
+  /**
+   * Custom Window Behavior
+   */
+  windowBehavior?: Function;
+  /**
+   * Override locales
+   */
+  locales?: any;
 };
 declare class DesktopServiceProvider extends ServiceProvider {
-	/**
-	 */
-	constructor(core: Core, options?: {});
-	/**
-	 */
-	readonly desktop: Desktop;
-	/**
-	 */
-	createDesktopContract(): DeskopProviderContract;
+  /**
+   */
+  constructor(core: Core, options?: {});
+  /**
+   */
+  readonly desktop: Desktop;
+  /**
+   */
+  createDesktopContract(): DeskopProviderContract;
 }
 /**
  * Desktop Service Contract
  */
 export type DeskopProviderContract = {
-	setKeyboardContext: Function;
-	openContextMenu: Function;
-	addContextMenuEntries: Function;
-	applySettings: Function;
-	createDropContextMenu: Function;
-	getRect: Function;
+  setKeyboardContext: Function;
+  openContextMenu: Function;
+  addContextMenuEntries: Function;
+  applySettings: Function;
+  createDropContextMenu: Function;
+  getRect: Function;
 };
 declare class NotificationServiceProvider extends ServiceProvider {
-	/**
-	 */
-	constructor(core: Core);
-	/**
-	 */
-	readonly notifications: Notifications;
+  /**
+   */
+  constructor(core: Core);
+  /**
+   */
+  readonly notifications: Notifications;
 }
 declare class Filesystem extends EventEmitter {
-	/**
-	 * Create filesystem manager
-	 */
-	constructor(core: Core, options?: FilesystemOptions);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Adapter registry
-	 */
-	readonly adapters: {
-		name: FilesystemAdapterWrapper;
-	};
-	/**
-	 * Mountpoints
-	 */
-	mounts: FilesystemMountpoint[];
-	/**
-	 * Options
-	 */
-	options: FilesystemOptions;
-	/**
-	 * A wrapper for VFS method requests
-	 */
-	readonly proxy: {
-		key: Function;
-	};
-	/**
-	 * Mounts all configured mountpoints
-	 */
-	mountAll(stopOnError?: boolean): Promise<boolean[]>;
-	/**
-	 * Adds a new mountpoint
-	 */
-	addMountpoint(props: FilesystemMountpoint, automount?: boolean): Promise<boolean>;
-	/**
-	 * Mount given filesystem
-	 */
-	mount(m: string|FilesystemMountpoint): Promise<boolean>;
-	/**
-	 * Unmount given filesystem
-	 */
-	unmount(name: string): Promise<boolean>;
-	/**
-	 * Internal wrapper for mounting/unmounting
-	 */
-	private _mountpointAction;
-	/**
-	 * Internal wrapper for mounting/unmounting by name
-	 */
-	private _mountAction;
-	/**
-	 * Gets the proxy for VFS methods
-	 */
-	request(): FilesystemAdapterMethods;
-	/**
-	 * Perform a VFS method request
-	 */
-	private _request;
-	/**
-	 * Request action wrapper
-	 */
-	private _requestAction;
-	/**
-	 * Creates a new mountpoint based on given properties
-	 */
-	createMountpoint(props: FilesystemMountpoint): FilesystemMountpoint;
-	/**
-	 * Gets mountpoint from given path
-	 */
-	getMountpointFromPath(file: string | any): FilesystemMountpoint | null;
-	/**
-	 * Gets all mountpoints
-	 */
-	getMounts(all?: boolean): FilesystemMountpoint[];
-	/**
-	 * Gets configured mountpoints
-	 */
-	private _getConfiguredMountpoints;
+  /**
+   * Create filesystem manager
+   */
+  constructor(core: Core, options?: FilesystemOptions);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Adapter registry
+   */
+  readonly adapters: {
+    name: FilesystemAdapterWrapper;
+  };
+  /**
+   * Mountpoints
+   */
+  mounts: FilesystemMountpoint[];
+  /**
+   * Options
+   */
+  options: FilesystemOptions;
+  /**
+   * A wrapper for VFS method requests
+   */
+  readonly proxy: {
+    key: Function;
+  };
+  /**
+   * Mounts all configured mountpoints
+   */
+  mountAll(stopOnError?: boolean): Promise<boolean[]>;
+  /**
+   * Adds a new mountpoint
+   */
+  addMountpoint(props: FilesystemMountpoint, automount?: boolean): Promise<boolean>;
+  /**
+   * Mount given filesystem
+   */
+  mount(m: string|FilesystemMountpoint): Promise<boolean>;
+  /**
+   * Unmount given filesystem
+   */
+  unmount(name: string): Promise<boolean>;
+  /**
+   * Internal wrapper for mounting/unmounting
+   */
+  private _mountpointAction;
+  /**
+   * Internal wrapper for mounting/unmounting by name
+   */
+  private _mountAction;
+  /**
+   * Gets the proxy for VFS methods
+   */
+  request(): FilesystemAdapterMethods;
+  /**
+   * Perform a VFS method request
+   */
+  private _request;
+  /**
+   * Request action wrapper
+   */
+  private _requestAction;
+  /**
+   * Creates a new mountpoint based on given properties
+   */
+  createMountpoint(props: FilesystemMountpoint): FilesystemMountpoint;
+  /**
+   * Gets mountpoint from given path
+   */
+  getMountpointFromPath(file: string | any): FilesystemMountpoint | null;
+  /**
+   * Gets all mountpoints
+   */
+  getMounts(all?: boolean): FilesystemMountpoint[];
+  /**
+   * Gets configured mountpoints
+   */
+  private _getConfiguredMountpoints;
 }
 /**
  * VFS Mountpoint attributes
  */
 export type FilesystemMountpointAttributes = {
-	/**
-	 * Visibility in UI
-	 */
-	visibility?: string;
-	/**
-	 * Local filesystem ?
-	 */
-	local?: boolean;
-	/**
-	 * If can be searched
-	 */
-	searchable?: boolean;
-	/**
-	 * Readonly
-	 */
-	readOnly?: boolean;
+  /**
+   * Visibility in UI
+   */
+  visibility?: string;
+  /**
+   * Local filesystem ?
+   */
+  local?: boolean;
+  /**
+   * If can be searched
+   */
+  searchable?: boolean;
+  /**
+   * Readonly
+   */
+  readOnly?: boolean;
 };
 /**
  * VFS Mountpoint
  */
 export type FilesystemMountpoint = {
-	/**
-	 * Name
-	 */
-	name: string;
-	/**
-	 * Label
-	 */
-	label: string;
-	/**
-	 * Adater name
-	 */
-	adapter: string;
-	/**
-	 * System adapter root
-	 */
-	root?: string;
-	/**
-	 * Enabled state
-	 */
-	enabled?: boolean;
-	/**
-	 * Attributes
-	 */
-	attributes?: FilesystemMountpointAttributes;
+  /**
+   * Name
+   */
+  name: string;
+  /**
+   * Label
+   */
+  label: string;
+  /**
+   * Adater name
+   */
+  adapter: string;
+  /**
+   * System adapter root
+   */
+  root?: string;
+  /**
+   * Enabled state
+   */
+  enabled?: boolean;
+  /**
+   * Attributes
+   */
+  attributes?: FilesystemMountpointAttributes;
 };
 /**
  * Filesystem Adapter Methods
  */
 export type FilesystemAdapterMethods = {
-	readdir: Function;
-	readfile: Function;
-	writefile: Function;
-	copy: Function;
-	move: Function;
-	rename: Function;
-	mkdir: Function;
-	unlink: Function;
-	exists: Function;
-	stat: Function;
-	url: Function;
-	download: Function;
-	search: Function;
-	touch: Function;
+  readdir: Function;
+  readfile: Function;
+  writefile: Function;
+  copy: Function;
+  move: Function;
+  rename: Function;
+  mkdir: Function;
+  unlink: Function;
+  exists: Function;
+  stat: Function;
+  url: Function;
+  download: Function;
+  search: Function;
+  touch: Function;
 };
 export type FilesystemAdapterWrapper = () => FilesystemAdapterMethods;
 /**
  * Filesystem Options
  */
 export type FilesystemOptions = {
-	/**
-	 * Adapter registry
-	 */
-	adapters?: {
-		name: FilesystemAdapterWrapper;
-	};
-	/**
-	 * Mountpoints
-	 */
-	mounts?: FilesystemMountpoint[];
+  /**
+   * Adapter registry
+   */
+  adapters?: {
+    name: FilesystemAdapterWrapper;
+  };
+  /**
+   * Mountpoints
+   */
+  mounts?: FilesystemMountpoint[];
 };
 declare class VFSServiceProvider extends ServiceProvider {
-	/**
-	 */
-	constructor(core: Core, options?: VFSServiceOptions);
-	/**
-	 */
-	readonly fs: Filesystem;
-	/**
-	 */
-	createVFSContract(): VFSServiceContract;
-	/**
-	 */
-	createFilesystemContract(): VFSServiceFilesystemContract;
+  /**
+   */
+  constructor(core: Core, options?: VFSServiceOptions);
+  /**
+   */
+  readonly fs: Filesystem;
+  /**
+   */
+  createVFSContract(): VFSServiceContract;
+  /**
+   */
+  createFilesystemContract(): VFSServiceFilesystemContract;
 }
 /**
  * Filesytem Service Contract
  */
 export type VFSServiceFilesystemContract = {
-	basename: Function;
-	pathname: Function;
-	pathJoin: Function;
-	icon: Function;
-	mountpoints: Function;
-	mount: Function;
-	unmount: Function;
+  basename: Function;
+  pathname: Function;
+  pathJoin: Function;
+  icon: Function;
+  mountpoints: Function;
+  mount: Function;
+  unmount: Function;
 };
 /**
  * VFS Service Contract
  */
 export type VFSServiceContract = {
-	readdir: Function;
-	readfile: Function;
-	writefile: Function;
-	copy: Function;
-	move: Function;
-	rename: Function;
-	mkdir: Function;
-	unlink: Function;
-	exists: Function;
-	stat: Function;
-	url: Function;
-	download: Function;
-	search: Function;
-	touch: Function;
+  readdir: Function;
+  readfile: Function;
+  writefile: Function;
+  copy: Function;
+  move: Function;
+  rename: Function;
+  mkdir: Function;
+  unlink: Function;
+  exists: Function;
+  stat: Function;
+  url: Function;
+  download: Function;
+  search: Function;
+  touch: Function;
 };
 /**
  * VFS Service Options
  */
 export type VFSServiceOptions = {
-	adapters?: {
-		name: any;
-	};
-	mountpoints?: any[];
+  adapters?: {
+    name: any;
+  };
+  mountpoints?: any[];
 };
 declare class AuthServiceProvider extends ServiceProvider {
-	/**
-	 */
-	constructor(core: Core, options?: AuthServiceOptions);
-	/**
-	 */
-	readonly auth: Auth;
-	/**
-	 */
-	createAuthContract(): AuthProviderContract;
+  /**
+   */
+  constructor(core: Core, options?: AuthServiceOptions);
+  /**
+   */
+  readonly auth: Auth;
+  /**
+   */
+  createAuthContract(): AuthProviderContract;
 }
 /**
  * Auth Service Contract
  */
 export type AuthProviderContract = {
-	show: Function;
-	login: Function;
-	logout: Function;
-	user: Function;
+  show: Function;
+  login: Function;
+  logout: Function;
+  user: Function;
 };
 /**
  * Auth Service Options
  */
 export type AuthServiceOptions = any;
 declare class Settings {
-	/**
-	 * Create application
-	 */
-	constructor(core: Core, options: SettingsOptions);
-	/**
-	 * The settings adapter
-	 */
-	readonly adapter: SettingsAdapter;
-	/**
-	 * Internal timeout reference used for debouncing
-	 */
-	debounce: object;
-	/**
-	 * The settings tree
-	 */
-	settings: {
-		name: any;
-	};
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Initializes settings adapter
-	 */
-	init(): any;
-	/**
-	 * Saves settings
-	 */
-	save(): Promise<boolean>;
-	/**
-	 * Loads settings
-	 */
-	load(): Promise<boolean>;
-	/**
-	 * Gets a settings entry by key (cached)
-	 */
-	get(ns?: string, key?: string, defaultValue?: any): any;
-	/**
-	 * Sets a settings entry by root key (but does not save).
-	 */
-	set(ns: string, key?: string, value?: any): Settings;
-	/**
-	 * Clears a namespace by root key
-	 */
-	clear(ns: string): Promise<boolean>;
+  /**
+   * Create application
+   */
+  constructor(core: Core, options: SettingsOptions);
+  /**
+   * The settings adapter
+   */
+  readonly adapter: SettingsAdapter;
+  /**
+   * Internal timeout reference used for debouncing
+   */
+  debounce: object;
+  /**
+   * The settings tree
+   */
+  settings: {
+    name: any;
+  };
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Initializes settings adapter
+   */
+  init(): any;
+  /**
+   * Saves settings
+   */
+  save(): Promise<boolean>;
+  /**
+   * Loads settings
+   */
+  load(): Promise<boolean>;
+  /**
+   * Gets a settings entry by key (cached)
+   */
+  get(ns?: string, key?: string, defaultValue?: any): any;
+  /**
+   * Sets a settings entry by root key (but does not save).
+   */
+  set(ns: string, key?: string, value?: any): Settings;
+  /**
+   * Clears a namespace by root key
+   */
+  clear(ns: string): Promise<boolean>;
 }
 /**
  */
@@ -2366,44 +2366,44 @@ export type SettingsAdapterCallback = (core: Core) => SettingsAdapterCallback;
  * Settings Options
  */
 export type SettingsOptions = {
-	/**
-	 * Adapter to use
-	 */
-	adapter?: SettingsAdapterCallback | SettingsAdapter;
-	/**
-	 * Adapter configuration
-	 */
-	config?: SettingsAdapterConfiguration;
+  /**
+   * Adapter to use
+   */
+  adapter?: SettingsAdapterCallback | SettingsAdapter;
+  /**
+   * Adapter configuration
+   */
+  config?: SettingsAdapterConfiguration;
 };
 declare class SettingsServiceProvider extends ServiceProvider {
-	/**
-	 */
-	constructor(core: Core, options?: SettingsServiceOptions);
-	/**
-	 */
-	readonly settings: Settings;
-	/**
-	 */
-	createSettingsContract(): SettingsProviderContract;
+  /**
+   */
+  constructor(core: Core, options?: SettingsServiceOptions);
+  /**
+   */
+  readonly settings: Settings;
+  /**
+   */
+  createSettingsContract(): SettingsProviderContract;
 }
 /**
  * Settings Service Contract
  */
 export type SettingsProviderContract = {
-	save: Function;
-	load: Function;
-	clear: Function;
-	set: Function;
-	get: Function;
+  save: Function;
+  load: Function;
+  clear: Function;
+  set: Function;
+  get: Function;
 };
 /**
  */
 export type SettingsServiceOptions = {
-	config?: any;
+  config?: any;
 };
 declare namespace instance {
-	export function addMiddleware(m: any): void;
-	export function clearMiddleware(): void;
+  export function addMiddleware(m: any): void;
+  export function clearMiddleware(): void;
 }
 /**
  * Basic Application Options
@@ -2418,129 +2418,129 @@ declare namespace instance {
  * Also sets the internal proc args for sessions.
  */
 export class BasicApplication extends EventEmitter {
-	/**
-	 * Basic Application Constructor
-	 */
-	constructor(core: Core, proc: Application, win: Window, options?: BasicApplicationOptions);
-	/**
-	 * Core instance reference
-	 */
-	readonly core: Core;
-	/**
-	 * Application instance reference
-	 */
-	readonly proc: Application;
-	/**
-	 * Window instance reference
-	 */
-	readonly win: Window;
-	/**
-	 * Basic Application Options
-	 */
-	readonly options: BasicApplicationOptions;
-	/**
-	 * Destroys all Basic Application internals
-	 */
-	destroy(): void;
-	/**
-	 * Initializes the application
-	 */
-	init(): Promise<boolean>;
-	/**
-	 * Gets options for a dialog
-	 */
-	getDialogOptions(type: string, options?: {}): object;
-	/**
-	 * Updates the window title to match open file
-	 */
-	updateWindowTitle(): void;
-	/**
-	 * Creates a new dialog of a type
-	 */
-	createDialog(type: string, cb: Function, options?: object): void;
-	/**
-	 * Opens given file
-	 * Does not do any actual VFS operation
-	 */
-	open(item: any): void;
-	/**
-	 * Saves given file
-	 * Does not do any actual VFS operation
-	 */
-	save(item: any): void;
-	/**
-	 * Create new file
-	 * Does not do any actual VFS operation
-	 */
-	create(): void;
-	/**
-	 * Create new file
-	 */
-	createNew(): void;
-	/**
-	 * Creates a new save dialog
-	 */
-	createSaveDialog(options?: object): void;
-	/**
-	 * Creates a new load dialog
-	 */
-	createOpenDialog(options?: object): void;
-	/**
-	 * Sets file from open/save action
-	 */
-	private _setFile;
-	/**
-	 * Creates the window title
-	 */
-	private _createTitle;
+  /**
+   * Basic Application Constructor
+   */
+  constructor(core: Core, proc: Application, win: Window, options?: BasicApplicationOptions);
+  /**
+   * Core instance reference
+   */
+  readonly core: Core;
+  /**
+   * Application instance reference
+   */
+  readonly proc: Application;
+  /**
+   * Window instance reference
+   */
+  readonly win: Window;
+  /**
+   * Basic Application Options
+   */
+  readonly options: BasicApplicationOptions;
+  /**
+   * Destroys all Basic Application internals
+   */
+  destroy(): void;
+  /**
+   * Initializes the application
+   */
+  init(): Promise<boolean>;
+  /**
+   * Gets options for a dialog
+   */
+  getDialogOptions(type: string, options?: {}): object;
+  /**
+   * Updates the window title to match open file
+   */
+  updateWindowTitle(): void;
+  /**
+   * Creates a new dialog of a type
+   */
+  createDialog(type: string, cb: Function, options?: object): void;
+  /**
+   * Opens given file
+   * Does not do any actual VFS operation
+   */
+  open(item: any): void;
+  /**
+   * Saves given file
+   * Does not do any actual VFS operation
+   */
+  save(item: any): void;
+  /**
+   * Create new file
+   * Does not do any actual VFS operation
+   */
+  create(): void;
+  /**
+   * Create new file
+   */
+  createNew(): void;
+  /**
+   * Creates a new save dialog
+   */
+  createSaveDialog(options?: object): void;
+  /**
+   * Creates a new load dialog
+   */
+  createOpenDialog(options?: object): void;
+  /**
+   * Sets file from open/save action
+   */
+  private _setFile;
+  /**
+   * Creates the window title
+   */
+  private _createTitle;
 }
 /**
  * Basic Application Options
  */
 export type BasicApplicationOptions = {
-	/**
-	 * What MIME types to support (all/fallback)
-	 */
-	mimeTypes?: string[];
-	/**
-	 * What MIME types to support on load
-	 */
-	loadMimeTypes?: string[];
-	/**
-	 * What MIME types to support on save
-	 */
-	saveMimeTypes?: string[];
-	/**
-	 * Default filename of a new file
-	 */
-	defaultFilename?: string;
+  /**
+   * What MIME types to support (all/fallback)
+   */
+  mimeTypes?: string[];
+  /**
+   * What MIME types to support on load
+   */
+  loadMimeTypes?: string[];
+  /**
+   * What MIME types to support on save
+   */
+  saveMimeTypes?: string[];
+  /**
+   * Default filename of a new file
+   */
+  defaultFilename?: string;
 };
 
 export {
-	Application as Application,
-	Auth as Auth,
-	AuthServiceProvider as AuthServiceProvider,
-	Clipboard as Clipboard,
-	Middleware as Middleware,
-	Core as Core,
-	CoreServiceProvider as CoreServiceProvider,
-	Desktop as Desktop,
-	DesktopServiceProvider as DesktopServiceProvider,
-	Filesystem as Filesystem,
-	Login as Login,
-	Notification as Notification,
-	NotificationServiceProvider as NotificationServiceProvider,
-	Notifications as Notifications,
-	Packages as Packages,
-	Search as Search,
-	Settings as Settings,
-	SettingsServiceProvider as SettingsServiceProvider,
-	Splash as Splash,
-	Tray as Tray,
-	VFSServiceProvider as VFSServiceProvider,
-	Websocket as Websocket,
-	Window as Window,
-	WindowBehavior as WindowBehavior,
-	instance as logger,
+  Application as Application,
+  Auth as Auth,
+  AuthServiceProvider as AuthServiceProvider,
+  Clipboard as Clipboard,
+  Middleware as Middleware,
+  Core as Core,
+  CoreServiceProvider as CoreServiceProvider,
+  Desktop as Desktop,
+  DesktopServiceProvider as DesktopServiceProvider,
+  Filesystem as Filesystem,
+  Login as Login,
+  Notification as Notification,
+  NotificationServiceProvider as NotificationServiceProvider,
+  Notifications as Notifications,
+  Packages as Packages,
+  Search as Search,
+  Settings as Settings,
+  SettingsServiceProvider as SettingsServiceProvider,
+  Splash as Splash,
+  Tray as Tray,
+  VFSServiceProvider as VFSServiceProvider,
+  Websocket as Websocket,
+  Window as Window,
+  WindowBehavior as WindowBehavior,
+  instance as logger,
 };
 

--- a/src/adapters/ui/search.js
+++ b/src/adapters/ui/search.js
@@ -44,7 +44,7 @@ const createView = (core, fs, icon, _) => {
       index === i ? 'osjs__active' : ''
     ].join(' ')
   }, [
-    h('img', {src: icon(fs.icon(r).name + '.png')}),
+    h('img', {src: icon(fs.icon(r).name)}),
     h('span', {}, `${r.path} (${r.mime})`)
   ]));
 

--- a/src/packages.js
+++ b/src/packages.js
@@ -496,6 +496,6 @@ export default class Packages {
    */
   getMetadataFromName(name) {
     const found = this.metadata.find(pkg => pkg.name === name);
-    return found ? { ...found } : null;
+    return found ? {...found} : null;
   }
 }

--- a/src/packages.js
+++ b/src/packages.js
@@ -495,6 +495,7 @@ export default class Packages {
    * @returns {PackageMetadata}
    */
   getMetadataFromName(name) {
-    return this.metadata.find(pkg => pkg.name === name);
+    const found = this.metadata.find(pkg => pkg.name === name);
+    return found ? { ...found } : null;
   }
 }

--- a/src/packages.js
+++ b/src/packages.js
@@ -488,4 +488,13 @@ export default class Packages {
   running() {
     return this._running;
   }
+
+  /**
+   * Gets the package metadata for a given package name
+   * @param {string} name
+   * @returns {PackageMetadata}
+   */
+  getMetadataFromName(name) {
+    return this.metadata.find(pkg => pkg.name === name);
+  }
 }

--- a/src/providers/core.js
+++ b/src/providers/core.js
@@ -451,7 +451,7 @@ export default class CoreServiceProvider extends ServiceProvider {
 
     return {
       resource: themeResource,
-      icon: name => icon(name.replace(/(\.png)?$/, '.png'))
+      icon
     };
   }
 

--- a/src/providers/core.js
+++ b/src/providers/core.js
@@ -502,7 +502,8 @@ export default class CoreServiceProvider extends ServiceProvider {
       addPackages: list => this.pm.addPackages(list),
       getPackages: filter => this.pm.getPackages(filter),
       getCompatiblePackages: mimeType => this.pm.getCompatiblePackages(mimeType),
-      running: () => this.pm.running()
+      running: () => this.pm.running(),
+      getMetadataFromName: name => this.pm.getMetadataFromName(name)
     };
   }
 

--- a/src/search.js
+++ b/src/search.js
@@ -88,7 +88,7 @@ export default class Search {
 
     this.core.make('osjs/tray').create({
       title: _('LBL_SEARCH_TOOLTOP', 'F3'),
-      icon: icon('system-search.png')
+      icon: icon('system-search')
     }, () => this.show());
 
     this.ui = createUI(this.core, this.$element);

--- a/src/styles/_search.scss
+++ b/src/styles/_search.scss
@@ -28,6 +28,8 @@
  * @license Simplified BSD License
  */
 
+$search-image-size: 16px;
+
 .osjs-search {
   position: absolute;
   top: 50%;
@@ -75,5 +77,7 @@
 
   img {
     margin-right: $base-margin;
+    width: $search-image-size;
+    height: $search-image-size;
   }
 }

--- a/src/utils/desktop.js
+++ b/src/utils/desktop.js
@@ -149,12 +149,14 @@ export const resourceResolver = (core) => {
   const soundsEnabled = () => !!getSoundThemeName();
 
   const icon = (name) => {
-    const theme = getThemeName('icons');
-    const extension = core.make('osjs/packages')
-      .getMetadataFromName(theme)
-      .icons[name] || 'png';
+    name = name.replace(/\.(png|svg|gif)$/, '');
+    const {getMetadataFromName} = core.make('osjs/packages');
+		const theme = getThemeName('icons');
+		const metadata = getMetadataFromName(theme) || {};
+		const iconDefinitions = metadata.icons || {};
+		const extension = iconDefinitions[name] || 'png';
 
-    return core.url(`icons/${theme}/icons/${name}.${extension}`);
+		return core.url(`icons/${theme}/icons/${name}.${extension}`);
   };
 
   return {themeResource, soundResource, soundsEnabled, icon};

--- a/src/utils/desktop.js
+++ b/src/utils/desktop.js
@@ -35,7 +35,8 @@ const imageDropMimes = [
   'image/png',
   'image/jpe?g',
   'image/webp',
-  'image/gif'
+  'image/gif',
+  'image/svg(\\+xml)?'
 ];
 
 /**
@@ -110,6 +111,21 @@ export const isVisible = w => w &&
   !w.getState('minimized') &&
   w.getState('focused');
 
+/**
+ * Allows for requesting whether a file exists without `async`
+ * @todo Move to VFS, so the 404 error doesn't log to console
+ * @param {string} urlToFile
+ * @returns {boolean}
+ */
+const syncRequest = (urlToFile) => {
+  const xhr = new XMLHttpRequest();
+  xhr.open('HEAD', urlToFile, false);
+  xhr.send();
+
+  return xhr.status > 199 && xhr.status < 300;
+};
+
+
 /*
  * Resolves various resources
  * TODO: Move all of this (and related) stuff to a Theme class
@@ -149,7 +165,32 @@ export const resourceResolver = (core) => {
 
   const icon = path => {
     const theme = getThemeName('icons');
-    return core.url(`icons/${theme}/icons/${path}`); // FIXME: Use metadata ?
+    const urlBase = `icons/${theme}/icons`;
+
+    if (!path.match(/\.([a-z]+)$/)) {
+      const defaultExtension = 'png';
+      const defaultImage = core.url(`${urlBase}/${path}.${defaultExtension}`);
+      const defaultImageExists = syncRequest(defaultImage);
+      if (defaultImageExists) {
+        path += '.' + defaultExtension;
+      } else {
+        const checkExtensions = ['svg', 'gif'];
+        for (const ext of checkExtensions) {
+          const url = core.url(`${urlBase}/${path}.${ext}`);
+          const urlExists = syncRequest(url);
+          if (urlExists) {
+            path += '.' + ext;
+            break;
+          }
+        }
+
+        if (!path.match(/\.([a-z]+)$/)) {
+          path += '.' + defaultExtension;
+        }
+      }
+    }
+
+    return core.url(`${urlBase}/${path}`);
   };
 
   return {themeResource, soundResource, soundsEnabled, icon};

--- a/src/utils/desktop.js
+++ b/src/utils/desktop.js
@@ -111,21 +111,6 @@ export const isVisible = w => w &&
   !w.getState('minimized') &&
   w.getState('focused');
 
-/**
- * Allows for requesting whether a file exists without `async`
- * @todo Move to VFS, so the 404 error doesn't log to console
- * @param {string} urlToFile
- * @returns {boolean}
- */
-const syncRequest = (urlToFile) => {
-  const xhr = new XMLHttpRequest();
-  xhr.open('HEAD', urlToFile, false);
-  xhr.send();
-
-  return xhr.status > 199 && xhr.status < 300;
-};
-
-
 /*
  * Resolves various resources
  * TODO: Move all of this (and related) stuff to a Theme class
@@ -163,34 +148,13 @@ export const resourceResolver = (core) => {
 
   const soundsEnabled = () => !!getSoundThemeName();
 
-  const icon = path => {
+  const icon = (name) => {
     const theme = getThemeName('icons');
-    const urlBase = `icons/${theme}/icons`;
+    const extension = core.make('osjs/packages')
+      .getMetadataFromName(theme)
+      .icons[name] || 'png';
 
-    if (!path.match(/\.([a-z]+)$/)) {
-      const defaultExtension = 'png';
-      const defaultImage = core.url(`${urlBase}/${path}.${defaultExtension}`);
-      const defaultImageExists = syncRequest(defaultImage);
-      if (defaultImageExists) {
-        path += '.' + defaultExtension;
-      } else {
-        const checkExtensions = ['svg', 'gif'];
-        for (const ext of checkExtensions) {
-          const url = core.url(`${urlBase}/${path}.${ext}`);
-          const urlExists = syncRequest(url);
-          if (urlExists) {
-            path += '.' + ext;
-            break;
-          }
-        }
-
-        if (!path.match(/\.([a-z]+)$/)) {
-          path += '.' + defaultExtension;
-        }
-      }
-    }
-
-    return core.url(`${urlBase}/${path}`);
+    return core.url(`icons/${theme}/icons/${name}.${extension}`);
   };
 
   return {themeResource, soundResource, soundsEnabled, icon};

--- a/src/utils/desktop.js
+++ b/src/utils/desktop.js
@@ -151,12 +151,12 @@ export const resourceResolver = (core) => {
   const icon = (name) => {
     name = name.replace(/\.(png|svg|gif)$/, '');
     const {getMetadataFromName} = core.make('osjs/packages');
-		const theme = getThemeName('icons');
-		const metadata = getMetadataFromName(theme) || {};
-		const iconDefinitions = metadata.icons || {};
-		const extension = iconDefinitions[name] || 'png';
+    const theme = getThemeName('icons');
+    const metadata = getMetadataFromName(theme) || {};
+    const iconDefinitions = metadata.icons || {};
+    const extension = iconDefinitions[name] || 'png';
 
-		return core.url(`icons/${theme}/icons/${name}.${extension}`);
+    return core.url(`icons/${theme}/icons/${name}.${extension}`);
   };
 
   return {themeResource, soundResource, soundsEnabled, icon};


### PR DESCRIPTION
This PR allows themes to include icons of type `SVG`, `PNG`, and `GIF`, the three primary formats used for images with transparency. The code makes a request to check if the default image type `.png` exists first, and if not it then checks for `.svg` and `.gif` images, respectfully. The styles in `_search.scss` were updated to enforce a standard size on `SVG` files, which could show up much larger than expected otherwise.

I chose this method because the proposed solutions in #150 were either:
1. Complicated and involved a lot of JSON configuration, which is an unnecessary barrier for users interested in introducing new themes
2. Didn't allow for mix-and-match of icon formats, which is something that is worth considering (I have had to introduce a `.png` in a theme because there was no equivalent `.svg` in the theme I was modifying)

My solution is not perfect, but it functions as intended. Reviews and critiques are of course always welcome :)

---

Closes #150
Refs #172