### PR TITLE
fix: remove hidden packages from mime-compatible packages list

### DIFF
--- a/__tests__/packages.js
+++ b/__tests__/packages.js
@@ -22,6 +22,13 @@ const packageList = [{
   type: 'application',
   singleton: true
 }, {
+  name: 'Package5',
+  type: 'application',
+  mimes: [
+    'video/mpeg'
+  ],
+  hidden: true
+}, {
   name: 'PackageMissingRuntime',
   type: 'application',
 }, {

--- a/src/packages.js
+++ b/src/packages.js
@@ -448,7 +448,7 @@ export default class Packages {
    */
   getCompatiblePackages(mimeType) {
     return this.getPackages(meta => {
-      if (meta.mimes) {
+      if (meta.mimes && !meta.hidden) {
         return !!meta.mimes.find(mime => {
           try {
             const re = new RegExp(mime);


### PR DESCRIPTION
This PR tries to hide `hidden` application from file-manager `open-with` menu. 